### PR TITLE
feature/add-reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Reboot system functionality from Power menu in TUI
+  - Added `RebootMsg` type in `internal/tui/models/types.go`
+  - Added `runReboot` handler in `internal/tui/models/debug.go`
+  - Added key handler in `internal/tui/models/key_handlers.go`
+
+### Changed
+-
+
+### Deprecated
+-
+
+### Removed
+-
+
+### Fixed
+-
+
+### Security
+-
+
+## [0.0.1] - 2026-04-12
+
+### Added
+- Initial release

--- a/internal/tui/models/debug.go
+++ b/internal/tui/models/debug.go
@@ -27,6 +27,24 @@ func runLBUCommit() tea.Cmd {
 	}
 }
 
+// runReboot executes the reboot command asynchronously
+func runReboot() tea.Cmd {
+	return func() tea.Msg {
+		if dryRunMode {
+			return RebootMsg{
+				Output:  "running: reboot",
+				Success: true,
+			}
+		}
+		cmd := exec.Command("/sbin/reboot")
+		err := cmd.Start()
+		return RebootMsg{
+				Output:  "Reboot initiated",
+				Success: err == nil,
+			}
+	}
+}
+
 // RunTestScenario runs a test scenario in non-interactive mode
 // This is used by the debug agent to test specific application states
 func (m *MainModel) RunTestScenario(scenario string) {

--- a/internal/tui/models/key_handlers.go
+++ b/internal/tui/models/key_handlers.go
@@ -104,6 +104,16 @@ func (m *MainModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Handle reboot completion
+	if rm, ok := msg.(RebootMsg); ok {
+		if rm.Success {
+			m.statusBar.SetMessage("Reboot: " + rm.Output)
+		} else {
+			m.statusBar.SetMessage("Reboot failed: " + rm.Output)
+		}
+		return m, nil
+	}
+
 	// If we're in VM creation view, delegate to that model
 	if m.currentView == ViewVMCreate && m.vmCreateModel != nil {
 		// Forward file/disk selection messages to sub-view
@@ -553,7 +563,8 @@ func (m *MainModel) handlePowerSelection() (tea.Model, tea.Cmd) {
 	selectedIndex := m.powerList.Index()
 	switch selectedIndex {
 	case 0:
-		m.statusBar.SetMessage("Reboot system: Feature coming soon")
+		// Reboot system
+		return m, runReboot()
 	case 1:
 		m.statusBar.SetMessage("Power off system: Feature coming soon")
 	}

--- a/internal/tui/models/types.go
+++ b/internal/tui/models/types.go
@@ -52,6 +52,12 @@ type LBUCommitMsg struct {
 	Success bool
 }
 
+// RebootMsg is sent when a reboot operation completes
+type RebootMsg struct {
+	Output  string
+	Success bool
+}
+
 // MainModel is the main model for the application
 type MainModel struct {
 	// Current view


### PR DESCRIPTION
## Description

Adds reboot functionality to the VM management interface.

## Changes

- CHANGELOG.md: +34 lines
- internal/tui/models/debug.go: +18 lines
- internal/tui/models/key_handlers.go: +13 lines
- internal/tui/models/types.go: +6 lines

Total: 4 files changed, 70 insertions(+), 1 deletion(-)

## Linked Issue

Closes #1