### PR TITLE
Add poweroff support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `RebootMsg` type in `internal/tui/models/types.go`
   - Added `runReboot` handler in `internal/tui/models/debug.go`
   - Added key handler in `internal/tui/models/key_handlers.go`
+- Power off system functionality from Power menu in TUI
+  - Added `PowerOffMsg` type in `internal/tui/models/types.go`
+  - Added `runPowerOff` handler in `internal/tui/models/debug.go`
+  - Added key handler in `internal/tui/models/key_handlers.go`
 
 ### Changed
 -

--- a/internal/tui/models/debug.go
+++ b/internal/tui/models/debug.go
@@ -45,6 +45,24 @@ func runReboot() tea.Cmd {
 	}
 }
 
+// runPowerOff executes the poweroff command asynchronously
+func runPowerOff() tea.Cmd {
+	return func() tea.Msg {
+		if dryRunMode {
+			return PowerOffMsg{
+				Output:  "running: poweroff",
+				Success: true,
+			}
+		}
+		cmd := exec.Command("/sbin/poweroff")
+		err := cmd.Start()
+		return PowerOffMsg{
+				Output:  "Power off initiated",
+				Success: err == nil,
+			}
+	}
+}
+
 // RunTestScenario runs a test scenario in non-interactive mode
 // This is used by the debug agent to test specific application states
 func (m *MainModel) RunTestScenario(scenario string) {

--- a/internal/tui/models/key_handlers.go
+++ b/internal/tui/models/key_handlers.go
@@ -114,6 +114,16 @@ func (m *MainModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Handle power off completion
+	if pom, ok := msg.(PowerOffMsg); ok {
+		if pom.Success {
+			m.statusBar.SetMessage("Power off: " + pom.Output)
+		} else {
+			m.statusBar.SetMessage("Power off failed: " + pom.Output)
+		}
+		return m, nil
+	}
+
 	// If we're in VM creation view, delegate to that model
 	if m.currentView == ViewVMCreate && m.vmCreateModel != nil {
 		// Forward file/disk selection messages to sub-view
@@ -566,7 +576,8 @@ func (m *MainModel) handlePowerSelection() (tea.Model, tea.Cmd) {
 		// Reboot system
 		return m, runReboot()
 	case 1:
-		m.statusBar.SetMessage("Power off system: Feature coming soon")
+		// Power off system
+		return m, runPowerOff()
 	}
 	return m, nil
 }

--- a/internal/tui/models/types.go
+++ b/internal/tui/models/types.go
@@ -58,6 +58,12 @@ type RebootMsg struct {
 	Success bool
 }
 
+// PowerOffMsg is sent when a power off operation completes
+type PowerOffMsg struct {
+	Output  string
+	Success bool
+}
+
 // MainModel is the main model for the application
 type MainModel struct {
 	// Current view


### PR DESCRIPTION
## Summary
Adds poweroff functionality to DKVM Manager, allowing users to shut down the host system directly from the TUI.

## Changes
- Add PowerOffMsg type for handling power off operation results
- Implement runPowerOff() to execute /sbin/poweroff
- Add key handler for power off action

## Files Changed
- internal/tui/models/types.go (+6 lines)
- internal/tui/models/debug.go (+18 lines)
- internal/tui/models/key_handlers.go (+12 lines)
- CHANGELOG.md (+4 lines)

Closes #3