### PR TITLE
feat: Add LVM striping support for logical volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Stripped logical volumes**: Option to create striped LVMs when Volume Group has multiple PVs (auto-enabled by default)
+
 ## [0.0.1] - 2025-04-19
 
 ### Added

--- a/internal/tui/models/lv_create_form.go
+++ b/internal/tui/models/lv_create_form.go
@@ -146,12 +146,22 @@ func (m *LVCreateFormModel) loadVolumeGroupsCmd() tea.Cmd {
 			log.Printf("[DEBUG] LV create: uid=%d euid=%d", os.Getuid(), os.Geteuid())
 		}
 
+		// Use literal tab character (not "\t" string) for --separator
 		argsPrimary := []string{"--noheadings", "-o", "vg_name,vg_size,vg_free,lv_count,pv_count", "--units", "g", "--separator", "\t"}
+		// Convert actual tab to string for logging display
+		argsPrimaryDisplay := make([]string, len(argsPrimary))
+		for i, a := range argsPrimary {
+			if a == "\t" {
+				argsPrimaryDisplay[i] = "'<TAB>'"
+			} else {
+				argsPrimaryDisplay[i] = a
+			}
+		}
 		cmd := exec.Command("vgs", argsPrimary...)
 		cmd.Env = append(os.Environ(), "LVM_SUPPRESS_FD_WARNINGS=1")
 		out, err := cmd.CombinedOutput()
 		if debugMode {
-			log.Printf("[DEBUG] LV create: running: vgs %s", strings.Join(argsPrimary, " "))
+			log.Printf("[DEBUG] LV create: running: vgs %s", strings.Join(argsPrimaryDisplay, " "))
 			log.Printf("[DEBUG] LV create: primary output raw=%q", strings.TrimSpace(string(out)))
 		}
 		if err != nil {
@@ -372,7 +382,12 @@ func (m *LVCreateFormModel) buildCommand() string {
 		cmd += " --type thin"
 	}
 	if m.isStripped {
-		cmd += " --stripes"
+		// Auto-stripes uses number of PVs in the VG
+		stripeCount := m.selectedVGPVCount()
+		if stripeCount < 2 {
+			stripeCount = 2 // Minimum 2 stripes if enabled
+		}
+		cmd += fmt.Sprintf(" --stripes %d", stripeCount)
 	}
 	if m.isContiguous {
 		cmd += " --contiguous y"

--- a/internal/tui/models/lv_create_form.go
+++ b/internal/tui/models/lv_create_form.go
@@ -23,6 +23,7 @@ type VolumeGroup struct {
 	Size    string
 	Free    string
 	LVCount int
+	PVCount int
 }
 
 type lvCreateFocus int
@@ -33,6 +34,7 @@ const (
 	lvFocusSize
 	lvFocusUnit
 	lvFocusThin
+	lvFocusStripped
 	lvFocusContig
 	lvFocusRO
 	lvFocusCreate
@@ -52,6 +54,7 @@ type LVCreateFormModel struct {
 	sizeValue        string
 	unitIndex        int
 	isThinPool       bool
+	isStripped       bool
 	isContiguous     bool
 	isReadOnly       bool
 	focusIndex       int
@@ -110,6 +113,10 @@ func (m *LVCreateFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.vgDropdownIndex < 0 || m.vgDropdownIndex >= len(m.volumeGroups) {
 				m.vgDropdownIndex = m.vgIndex
 			}
+			// Auto-enable stripped if first VG has more than 1 PV
+			if m.selectedVGPVCount() > 1 {
+				m.isStripped = true
+			}
 		}
 		m.syncViewport()
 	}
@@ -139,7 +146,7 @@ func (m *LVCreateFormModel) loadVolumeGroupsCmd() tea.Cmd {
 			log.Printf("[DEBUG] LV create: uid=%d euid=%d", os.Getuid(), os.Geteuid())
 		}
 
-		argsPrimary := []string{"--noheadings", "-o", "vg_name,vg_size,vg_free,lv_count", "--units", "g", "--separator", "\t"}
+		argsPrimary := []string{"--noheadings", "-o", "vg_name,vg_size,vg_free,lv_count,pv_count", "--units", "g", "--separator", "\t"}
 		cmd := exec.Command("vgs", argsPrimary...)
 		cmd.Env = append(os.Environ(), "LVM_SUPPRESS_FD_WARNINGS=1")
 		out, err := cmd.CombinedOutput()
@@ -170,7 +177,7 @@ func (m *LVCreateFormModel) loadVolumeGroupsCmd() tea.Cmd {
 		}
 
 		// Fallback for environments that ignore separator flags or format unexpectedly.
-		argsFallback := []string{"--noheadings", "-o", "vg_name,vg_size,vg_free,lv_count", "--units", "g"}
+		argsFallback := []string{"--noheadings", "-o", "vg_name,vg_size,vg_free,lv_count,pv_count", "--units", "g"}
 		fallbackCmd := exec.Command("vgs", argsFallback...)
 		fallbackCmd.Env = append(os.Environ(), "LVM_SUPPRESS_FD_WARNINGS=1")
 		fallbackOut, fallbackErr := fallbackCmd.CombinedOutput()
@@ -210,7 +217,7 @@ func parseVGSOutput(output string) ([]VolumeGroup, error) {
 		if debugMode {
 			log.Printf("[DEBUG] LV create: parse line=%q parts=%q", line, parts)
 		}
-		if len(parts) < 4 {
+		if len(parts) < 5 {
 			continue
 		}
 
@@ -227,11 +234,16 @@ func parseVGSOutput(output string) ([]VolumeGroup, error) {
 		if cntErr != nil {
 			continue
 		}
+		pvCnt, pvErr := strconv.Atoi(strings.TrimSpace(parts[4]))
+		if pvErr != nil {
+			pvCnt = 1
+		}
 		out = append(out, VolumeGroup{
 			Name:    name,
 			Size:    size,
 			Free:    free,
 			LVCount: cnt,
+			PVCount: pvCnt,
 		})
 	}
 	return out, nil
@@ -255,6 +267,37 @@ func (m *LVCreateFormModel) selectedVG() string {
 		return m.volumeGroups[m.vgIndex].Name
 	}
 	return ""
+}
+
+func (m *LVCreateFormModel) selectedVGPVCount() int {
+	if m.vgIndex >= 0 && m.vgIndex < len(m.volumeGroups) {
+		return m.volumeGroups[m.vgIndex].PVCount
+	}
+	return 0
+}
+
+// nextFocus returns the next focus index, skipping Stripped if VG has <= 1 PV.
+func (m *LVCreateFormModel) nextFocus(delta int) int {
+	maxFocus := 9
+	pvCount := m.selectedVGPVCount()
+	hasStrippedFocus := pvCount > 1
+
+	newFocus := m.focusIndex + delta
+	if newFocus < 0 {
+		newFocus = maxFocus - 1
+	} else if newFocus >= maxFocus {
+		newFocus = 0
+	}
+
+	// If we're on Stripped focus but VG has <= 1 PV, skip it
+	if newFocus == int(lvFocusStripped) && !hasStrippedFocus {
+		if delta > 0 {
+			newFocus = int(lvFocusContig)
+		} else {
+			newFocus = int(lvFocusThin)
+		}
+	}
+	return newFocus
 }
 
 func (m *LVCreateFormModel) openVGDropdown() {
@@ -285,6 +328,12 @@ func (m *LVCreateFormModel) confirmVGSelection() {
 		m.vgDropdownIndex = len(m.volumeGroups) - 1
 	}
 	m.vgIndex = m.vgDropdownIndex
+	// Auto-enable stripped if VG has more than 1 PV
+	if m.selectedVGPVCount() > 1 {
+		m.isStripped = true
+	} else {
+		m.isStripped = false
+	}
 	m.closeVGDropdown()
 }
 
@@ -321,6 +370,9 @@ func (m *LVCreateFormModel) buildCommand() string {
 	cmd := fmt.Sprintf("lvcreate -L %s%s -n %s %s", m.sizeValue, suffix, m.volumeName, vg)
 	if m.isThinPool {
 		cmd += " --type thin"
+	}
+	if m.isStripped {
+		cmd += " --stripes"
 	}
 	if m.isContiguous {
 		cmd += " --contiguous y"
@@ -430,8 +482,11 @@ func (m *LVCreateFormModel) renderLines() []string {
 	}
 	lines = append(lines,
 		fmt.Sprintf("  %s Thin pool              %s Contiguous", cb(m.isThinPool, m.focusIndex == int(lvFocusThin)), cb(m.isContiguous, m.focusIndex == int(lvFocusContig))),
-		fmt.Sprintf("  %s Read-only", cb(m.isReadOnly, m.focusIndex == int(lvFocusRO))),
 	)
+	if m.selectedVGPVCount() > 1 {
+		lines = append(lines, fmt.Sprintf("  %s Stripped", cb(m.isStripped, m.focusIndex == int(lvFocusStripped))))
+	}
+	lines = append(lines, fmt.Sprintf("  %s Read-only", cb(m.isReadOnly, m.focusIndex == int(lvFocusRO))))
 	if len(m.errors) > 0 {
 		lines = append(lines, "")
 		for _, k := range []string{"vg", "name", "size"} {
@@ -464,30 +519,24 @@ func (m *LVCreateFormModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.vgDropdownOpen {
 			m.closeVGDropdown()
 		}
-		m.focusIndex = (m.focusIndex + 1) % 9
+		m.focusIndex = m.nextFocus(1)
 	case "shift+tab":
 		if m.vgDropdownOpen {
 			m.closeVGDropdown()
 		}
-		m.focusIndex--
-		if m.focusIndex < 0 {
-			m.focusIndex = 8
-		}
+		m.focusIndex = m.nextFocus(-1)
 	case "down":
 		if m.focusIndex == int(lvFocusVG) && m.vgDropdownOpen {
 			m.moveVGSelection(1)
 			break
 		}
-		m.focusIndex = (m.focusIndex + 1) % 9
+		m.focusIndex = m.nextFocus(1)
 	case "up":
 		if m.focusIndex == int(lvFocusVG) && m.vgDropdownOpen {
 			m.moveVGSelection(-1)
 			break
 		}
-		m.focusIndex--
-		if m.focusIndex < 0 {
-			m.focusIndex = 8
-		}
+		m.focusIndex = m.nextFocus(-1)
 	case "left":
 		switch lvCreateFocus(m.focusIndex) {
 		case lvFocusVG:
@@ -520,6 +569,8 @@ func (m *LVCreateFormModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		switch lvCreateFocus(m.focusIndex) {
 		case lvFocusThin:
 			m.isThinPool = !m.isThinPool
+		case lvFocusStripped:
+			m.isStripped = !m.isStripped
 		case lvFocusContig:
 			m.isContiguous = !m.isContiguous
 		case lvFocusRO:

--- a/internal/tui/models/lv_create_form.go
+++ b/internal/tui/models/lv_create_form.go
@@ -288,7 +288,7 @@ func (m *LVCreateFormModel) selectedVGPVCount() int {
 
 // nextFocus returns the next focus index, skipping Stripped if VG has <= 1 PV.
 func (m *LVCreateFormModel) nextFocus(delta int) int {
-	maxFocus := 9
+	maxFocus := 10
 	pvCount := m.selectedVGPVCount()
 	hasStrippedFocus := pvCount > 1
 
@@ -343,6 +343,10 @@ func (m *LVCreateFormModel) confirmVGSelection() {
 		m.isStripped = true
 	} else {
 		m.isStripped = false
+	}
+	// Adjust focus if we moved off Stripped option while it was enabled
+	if !m.isStripped && m.focusIndex >= int(lvFocusStripped) && m.focusIndex < int(lvFocusContig) {
+		m.focusIndex = int(lvFocusContig)
 	}
 	m.closeVGDropdown()
 }

--- a/internal/tui/models/lv_create_form_test.go
+++ b/internal/tui/models/lv_create_form_test.go
@@ -234,6 +234,7 @@ func TestLVCreateRenderDropdownOpen(t *testing.T) {
 	m.vgDropdownOpen = true
 	m.vgDropdownIndex = 0
 	m.SetSize(76, 18)
+	m.syncViewport()
 
 	view := stripANSI(m.View())
 	assertGolden(t, "lv_create_form_vg_dropdown_open", view)
@@ -261,6 +262,7 @@ func TestLVCreateStrippedNotShownWithSinglePV(t *testing.T) {
 	// VG with 1 PV should NOT show stripped option
 	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g", PVCount: 1}}
 	m.vgIndex = 0
+	m.syncViewport()
 
 	view := m.View()
 	if strings.Contains(view, "Stripped") {
@@ -275,6 +277,7 @@ func TestLVCreateStrippedShownWithMultiplePVs(t *testing.T) {
 	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g", PVCount: 2, LVCount: 3}}
 	m.vgIndex = 0
 	m.isStripped = true
+	m.syncViewport()
 
 	view := m.View()
 	if !strings.Contains(view, "Stripped") {

--- a/internal/tui/models/lv_create_form_test.go
+++ b/internal/tui/models/lv_create_form_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestParseVGSOutput(t *testing.T) {
-	out := "ubuntu-vg\t500.00g\t300.00g\t2\nvg0\t100.00g\t10.00g\t5\n"
+	out := "ubuntu-vg\t500.00g\t300.00g\t2\t1\nvg0\t100.00g\t10.00g\t5\t3\n"
 	vgs, err := parseVGSOutput(out)
 	if err != nil {
 		t.Fatalf("parseVGSOutput() error: %v", err)
@@ -18,11 +18,14 @@ func TestParseVGSOutput(t *testing.T) {
 	}
 	if vgs[0].Name != "ubuntu-vg" || vgs[1].Name != "vg0" {
 		t.Fatalf("unexpected vg parse result: %#v", vgs)
+	}
+	if vgs[0].PVCount != 1 || vgs[1].PVCount != 3 {
+		t.Fatalf("unexpected pv count: %#v", vgs)
 	}
 }
 
 func TestParseVGSOutputWhitespaceAndEmptyLines(t *testing.T) {
-	out := "\n  ubuntu-vg\t500.00g\t300.00g\t2\n\t\ninvalid line\n  vg0\t100.00g\t10.00g\t5\n"
+	out := "\n  ubuntu-vg\t500.00g\t300.00g\t2\t2\n\t\ninvalid line\n  vg0\t100.00g\t10.00g\t5\t1\n"
 	vgs, err := parseVGSOutput(out)
 	if err != nil {
 		t.Fatalf("parseVGSOutput() error: %v", err)
@@ -33,10 +36,13 @@ func TestParseVGSOutputWhitespaceAndEmptyLines(t *testing.T) {
 	if vgs[0].Name != "ubuntu-vg" || vgs[1].Name != "vg0" {
 		t.Fatalf("unexpected vg parse result: %#v", vgs)
 	}
+	if vgs[0].PVCount != 2 || vgs[1].PVCount != 1 {
+		t.Fatalf("unexpected pv count: %#v", vgs)
+	}
 }
 
 func TestParseVGSOutputLiteralEscapedTabSeparator(t *testing.T) {
-	out := "vg_nvme\\t7452.04g\\t2798.04g\\t6\n"
+	out := "vg_nvme\\t7452.04g\\t2798.04g\\t6\\t4\n"
 	vgs, err := parseVGSOutput(out)
 	if err != nil {
 		t.Fatalf("parseVGSOutput() error: %v", err)
@@ -44,14 +50,14 @@ func TestParseVGSOutputLiteralEscapedTabSeparator(t *testing.T) {
 	if len(vgs) != 1 {
 		t.Fatalf("expected 1 VG, got %d", len(vgs))
 	}
-	if vgs[0].Name != "vg_nvme" || vgs[0].Free != "2798.04g" || vgs[0].LVCount != 6 {
+	if vgs[0].Name != "vg_nvme" || vgs[0].Free != "2798.04g" || vgs[0].LVCount != 6 || vgs[0].PVCount != 4 {
 		t.Fatalf("unexpected vg parse result: %#v", vgs[0])
 	}
 }
 
 func TestLVCreateValidate(t *testing.T) {
 	m := NewLVCreateFormModel()
-	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "10.00g"}}
+	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "10.00g", PVCount: 1}}
 	m.vgIndex = 0
 	m.volumeName = "ok-name"
 	m.sizeValue = "2"
@@ -73,7 +79,7 @@ func TestLVCreateValidate(t *testing.T) {
 func TestLVCreateFormNavigationAndToggle(t *testing.T) {
 	m := NewLVCreateFormModel()
 	m.SetSize(76, 18)
-	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "100.00g"}}
+	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "100.00g", PVCount: 1}}
 
 	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab, Runes: []rune{'\t'}}) // name
 	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab, Runes: []rune{'\t'}}) // size
@@ -95,7 +101,7 @@ func TestLVCreateDryRunCreate(t *testing.T) {
 
 	m := NewLVCreateFormModel()
 	m.SetSize(76, 18)
-	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "100.00g"}}
+	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "100.00g", PVCount: 1}}
 	m.vgIndex = 0
 	m.volumeName = "data"
 	m.sizeValue = "10"
@@ -121,7 +127,7 @@ func TestLVCreateEnterSubmitsFromNonCreateFocus(t *testing.T) {
 
 	m := NewLVCreateFormModel()
 	m.SetSize(76, 18)
-	m.volumeGroups = []VolumeGroup{{Name: "vg0", Free: "100.00g"}}
+	m.volumeGroups = []VolumeGroup{{Name: "vg0", Free: "100.00g", PVCount: 1}}
 	m.vgIndex = 0
 	m.volumeName = "data"
 	m.sizeValue = "10"
@@ -143,7 +149,7 @@ func TestLVCreateEnterSubmitsFromNonCreateFocus(t *testing.T) {
 func TestLVCreateEnterOnVGOpensDropdown(t *testing.T) {
 	m := NewLVCreateFormModel()
 	m.SetSize(76, 18)
-	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g"}, {Name: "vg0", Free: "10.00g"}}
+	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g", PVCount: 1}, {Name: "vg0", Free: "10.00g", PVCount: 1}}
 	m.vgIndex = 0
 	m.focusIndex = int(lvFocusVG)
 
@@ -159,7 +165,7 @@ func TestLVCreateEnterOnVGOpensDropdown(t *testing.T) {
 func TestLVCreateEnterOnVGWhenOpenConfirmsSelection(t *testing.T) {
 	m := NewLVCreateFormModel()
 	m.SetSize(76, 18)
-	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g"}, {Name: "vg0", Free: "10.00g"}}
+	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g", PVCount: 2}, {Name: "vg0", Free: "10.00g", PVCount: 1}}
 	m.vgIndex = 0
 	m.focusIndex = int(lvFocusVG)
 	m.vgDropdownOpen = true
@@ -177,7 +183,7 @@ func TestLVCreateEnterOnVGWhenOpenConfirmsSelection(t *testing.T) {
 func TestLVCreateEscClosesDropdownOnly(t *testing.T) {
 	m := NewLVCreateFormModel()
 	m.SetSize(76, 18)
-	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g"}}
+	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g", PVCount: 1}}
 	m.focusIndex = int(lvFocusVG)
 	m.vgDropdownOpen = true
 
@@ -193,7 +199,7 @@ func TestLVCreateEscClosesDropdownOnly(t *testing.T) {
 func TestLVCreateUpDownNavigatesVGDropdown(t *testing.T) {
 	m := NewLVCreateFormModel()
 	m.SetSize(76, 18)
-	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g"}, {Name: "vg0", Free: "10.00g"}}
+	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g", PVCount: 1}, {Name: "vg0", Free: "10.00g", PVCount: 1}}
 	m.focusIndex = int(lvFocusVG)
 	m.vgDropdownOpen = true
 	m.vgDropdownIndex = 0
@@ -223,7 +229,7 @@ func TestLVCreateRenderNoHardcodedVGFallback(t *testing.T) {
 
 func TestLVCreateRenderDropdownOpen(t *testing.T) {
 	m := NewLVCreateFormModel()
-	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g"}, {Name: "vg0", Free: "10.00g"}}
+	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g", PVCount: 1}, {Name: "vg0", Free: "10.00g", PVCount: 1}}
 	m.vgIndex = 0
 	m.vgDropdownOpen = true
 	m.vgDropdownIndex = 0
@@ -231,4 +237,75 @@ func TestLVCreateRenderDropdownOpen(t *testing.T) {
 
 	view := stripANSI(m.View())
 	assertGolden(t, "lv_create_form_vg_dropdown_open", view)
+}
+
+func TestLVCreateStrippedAutoEnabledWithMultiplePVs(t *testing.T) {
+	m := NewLVCreateFormModel()
+	m.SetSize(76, 18)
+	// VG with 2 PVs should have stripped auto-enabled
+	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g", PVCount: 2}}
+	m.vgIndex = 0
+
+	// Simulate loading VGs (triggers auto-enable)
+	_, _ = m.Update(lvVGsLoadedMsg{
+		vgs: []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g", PVCount: 2}},
+	})
+	if !m.isStripped {
+		t.Fatal("expected stripped to be auto-enabled for VG with 2 PVs")
+	}
+}
+
+func TestLVCreateStrippedNotShownWithSinglePV(t *testing.T) {
+	m := NewLVCreateFormModel()
+	m.SetSize(76, 18)
+	// VG with 1 PV should NOT show stripped option
+	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g", PVCount: 1}}
+	m.vgIndex = 0
+
+	view := m.View()
+	if strings.Contains(view, "Stripped") {
+		t.Fatal("expected Stripped option hidden for VG with 1 PV")
+	}
+}
+
+func TestLVCreateStrippedShownWithMultiplePVs(t *testing.T) {
+	m := NewLVCreateFormModel()
+	m.SetSize(76, 18)
+	// VG with 2 PVs should show stripped option
+	m.volumeGroups = []VolumeGroup{{Name: "ubuntu-vg", Free: "300.00g", PVCount: 2, LVCount: 3}}
+	m.vgIndex = 0
+	m.isStripped = true
+
+	view := m.View()
+	if !strings.Contains(view, "Stripped") {
+		t.Fatal("expected Stripped option shown for VG with 2 PVs")
+	}
+}
+
+func TestLVCreateBuildCommandWithStripes(t *testing.T) {
+	m := NewLVCreateFormModel()
+	m.volumeGroups = []VolumeGroup{{Name: "vg0", Free: "100.00g", PVCount: 2}}
+	m.vgIndex = 0
+	m.volumeName = "mylv"
+	m.sizeValue = "50"
+	m.isStripped = true
+
+	cmd := m.buildCommand()
+	if !strings.Contains(cmd, "--stripes") {
+		t.Fatalf("expected --stripes in command, got: %s", cmd)
+	}
+}
+
+func TestLVCreateBuildCommandWithoutStripes(t *testing.T) {
+	m := NewLVCreateFormModel()
+	m.volumeGroups = []VolumeGroup{{Name: "vg0", Free: "100.00g", PVCount: 1}}
+	m.vgIndex = 0
+	m.volumeName = "mylv"
+	m.sizeValue = "50"
+	m.isStripped = false
+
+	cmd := m.buildCommand()
+	if strings.Contains(cmd, "--stripes") {
+		t.Fatalf("expected no --stripes in command, got: %s", cmd)
+	}
 }

--- a/internal/tui/models/testdata/lv_create_form_stripped.golden
+++ b/internal/tui/models/testdata/lv_create_form_stripped.golden
@@ -1,0 +1,12 @@
+Create Logical Volume
+────────────────────────────────────────────────────────────────
+
+Volume Group: [                     ▼]
+Volume Name:  [my-data-volume       ]
+Size:         [100                   ▼]  GiB
+
+Options:
+  [ ] Thin pool              [ ] Contiguous
+  [x] Stripped               [ ] Read-only
+
+[Enter on Create] Create    [ESC] Cancel


### PR DESCRIPTION
## Description

Adds support for creating striped LVM logical volumes when the Volume Group has multiple physical volumes. Striping is automatically enabled by default for improved I/O performance.

## Changes

- **CHANGELOG.md**: Added entry for new feature
- **internal/tui/models/lv_create_form.go**: Added striping option to LV creation form (96 lines)
- **internal/tui/models/lv_create_form_test.go**: Added tests for striping functionality (106 lines)
- **internal/tui/models/testdata/lv_create_form_stripped.golden**: Added golden file for testing

## Files Changed

```
 CHANGELOG.md                                       |   4 +
 internal/tui/models/lv_create_form.go              |  96 ++++++++++++++++---
 internal/tui/models/lv_create_form_test.go         | 106 ++++++++++++++++++---
 .../models/testdata/lv_create_form_stripped.golden |  12 +++
 4 files changed, 190 insertions(+), 28 deletions(-)
```

Closes #19