### PR TITLE
fix(tui): improve running VM state tracking and UI robustness

### DIFF
--- a/internal/tui/components/tabs.go
+++ b/internal/tui/components/tabs.go
@@ -114,6 +114,11 @@ func (t *TabModel) PrevTab() Tab {
 // Active tab is bold and colored, inactive tabs are muted.
 // A positioned underline bar highlights the active tab.
 func (t *TabModel) RenderTabs(width int) string {
+	// Ensure minimum width for proper rendering
+	if width < 20 {
+		width = 20
+	}
+
 	separator := lipgloss.NewStyle().
 		Foreground(styles.Colors.Muted).
 		Render(" | ")
@@ -150,6 +155,9 @@ func (t *TabModel) RenderTabs(width int) string {
 
 	// Center the tab bar within the requested width
 	rowWidth := lipgloss.Width(contentRow)
+	if rowWidth == 0 {
+		rowWidth = offset
+	}
 	padding := 0
 	if rowWidth < width {
 		padding = (width - rowWidth) / 2

--- a/internal/tui/models/init.go
+++ b/internal/tui/models/init.go
@@ -184,5 +184,11 @@ func buildMenuItems(mgr *vm.Manager) []MenuItem {
 func (m *MainModel) rebuildMenuList() {
 	m.menuItems = buildMenuItems(m.vmManager)
 	m.menuList.SetItems(buildMenuListAdapter(m.menuItems))
-	m.statusBar.SetStats(len(m.menuItems), 0) // Running count is updated in handleVMSelection and handleVMStoppedMsg
+	
+	// Check if the VM that was running is still running
+	runningCount := 0
+	if m.runningVMID != "" && m.vmRunningModel != nil && m.vmRunningModel.Runner() != nil && m.vmRunningModel.Runner().IsRunning() {
+		runningCount = 1
+	}
+	m.statusBar.SetStats(len(m.menuItems), runningCount)
 }

--- a/internal/tui/models/key_handlers.go
+++ b/internal/tui/models/key_handlers.go
@@ -86,6 +86,8 @@ func (m *MainModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Handle VM stopped messages from running model
 	if vsm, ok := msg.(VMStoppedMsg); ok {
 		m.statusBar.SetMessage(fmt.Sprintf("VM '%s' stopped: %s", vsm.VMName, vsm.Reason))
+		// Clear running VM ID
+		m.runningVMID = ""
 		// Return to main menu when VM stops
 		m.currentView = ViewMainMenu
 		m.rebuildMenuList()
@@ -347,9 +349,14 @@ func (m *MainModel) forwardWindowSizeToSubView(msg tea.WindowSizeMsg) {
 func (m *MainModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	keyStr := msg.String()
 
-	// Global quit keys
+	// Global quit keys - check if a VM is running first
 	switch keyStr {
 	case "ctrl+c", "q":
+		// Check if a VM is running and warn user
+		if m.vmRunningModel != nil && m.vmRunningModel.Runner() != nil && m.vmRunningModel.Runner().IsRunning() {
+			m.statusBar.SetMessage("A VM is running. Press 'q' in the VM view to stop it first.")
+			return m, nil
+		}
 		m.quitting = true
 		return m, tea.Quit
 	}
@@ -592,11 +599,14 @@ func (m *MainModel) handleVMSelection() (tea.Model, tea.Cmd) {
 
 		// Update status bar to show this VM is running
 		m.statusBar.SetStats(len(m.menuItems), 1)
+		
+		// Track the running VM ID so status bar count survives rebuildMenuList
+		m.runningVMID = vmObj.ID
 
 		// Create running model
 		m.vmRunningModel = NewVMRunningModel(vmObj, runner)
+		m.vmRunningModel.startTime = time.Now() // Set before SetSize so uptime displays immediately
 		m.vmRunningModel.SetSize(m.windowWidth-4, m.contentHeight()-2)
-		m.vmRunningModel.startTime = time.Now()
 		m.currentView = ViewVMRunning
 		m.breadcrumbs.Clear()
 		m.breadcrumbs.AddItem("Start VM", "vms", 1)
@@ -665,7 +675,17 @@ func (m *MainModel) returnFromSubView() (tea.Model, tea.Cmd) {
 	case ViewVMCreate, ViewVMEdit, ViewVMDelete, ViewVMSelect, ViewCPUOptions, ViewPCIPassthrough, ViewUSBPassthrough, ViewCPUTopology, ViewVCPUPinning, ViewSSHPassword, ViewStartStopScript, ViewLVCreate:
 		m.tabModel.SetActiveTab(components.TabConfiguration)
 	case ViewVMRunning:
-		m.vmRunningModel = nil
+		// When leaving VMRunning view, keep the model if VM is still running 
+		// so we can track the running state, otherwise clear it
+		if m.vmRunningModel != nil && m.vmRunningModel.Runner() != nil && m.vmRunningModel.Runner().IsRunning() {
+			// VM is still running - keep the model and update runningVMID if needed
+			if m.runningVMID == "" {
+				m.runningVMID = m.vmRunningModel.Runner().VM().ID
+			}
+		} else {
+			m.vmRunningModel = nil
+			m.runningVMID = ""
+		}
 		m.tabModel.SetActiveTab(components.TabVMs)
 	default:
 		m.tabModel.SetActiveTab(components.TabVMs)

--- a/internal/tui/models/types.go
+++ b/internal/tui/models/types.go
@@ -124,6 +124,9 @@ type MainModel struct {
 	// SSH password model
 	sshPasswordModel *SSHPasswordModel
 
+	// Running VM ID - tracks the currently running VM to persist across rebuildMenuList calls
+	runningVMID string
+
 	// Start/Stop script form model
 	startStopScriptFormModel *StartStopScriptFormModel
 

--- a/internal/tui/models/vm_running.go
+++ b/internal/tui/models/vm_running.go
@@ -60,9 +60,6 @@ type VMRunningModel struct {
 	// Dimensions
 	width  int
 	height int
-
-	// Debug mode
-	debugMode bool
 }
 
 // NewVMRunningModel creates a new VM running model
@@ -71,7 +68,6 @@ func NewVMRunningModel(vmObj *models.VM, runner *vm.VMRunner) *VMRunningModel {
 		vm:          vmObj,
 		runner:      runner,
 		maxLogLines: 500,
-		debugMode:   debugMode,
 	}
 }
 


### PR DESCRIPTION
- Persist running VM count in status bar across menu rebuilds by tracking `runningVMID`
- Prevent application exit via 'q' or 'ctrl+c' while a VM is running to avoid orphaned processes
- Fix tab rendering by ensuring minimum width and handling zero-width rows
- Ensure VM start time is set before sizing to allow immediate uptime display
- Remove unused `debugMode` from `VMRunningModel`