### PR TITLE
feat(hugepages): implement automatic memory detection for VMs

### DIFF
--- a/internal/hugepages/hugepages.go
+++ b/internal/hugepages/hugepages.go
@@ -3,6 +3,7 @@
 package hugepages
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"os"
@@ -16,6 +17,9 @@ const (
 
 	// DefaultMemoryMB is the default memory size: 8GB
 	DefaultMemoryMB = 8192
+
+	// ReservedOSMemoryMB is memory reserved for the host OS: 4GB
+	ReservedOSMemoryMB = 4096
 )
 
 // Config holds hugepages configuration
@@ -24,12 +28,96 @@ type Config struct {
 	PageSize int64 // Hugepage size (default: 2MB)
 }
 
-// NewConfig creates a config for default 8GB hugepages
-func NewConfig() *Config {
-	return &Config{
-		MemMB:    DefaultMemoryMB,
-		PageSize: HugepageSize2MB,
+// GetTotalSystemMemoryMB reads /proc/meminfo and returns the total system memory in MB.
+func GetTotalSystemMemoryMB() (int64, error) {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0, fmt.Errorf("failed to read /proc/meminfo: %w", err)
 	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "MemTotal:") {
+			// Extract the value in kB (MemTotal is in kilobytes)
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+			kb, err := strconv.ParseInt(fields[1], 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("failed to parse MemTotal: %w", err)
+			}
+			// Convert kB to MB
+			return kb / 1024, nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("error scanning meminfo: %w", err)
+	}
+
+	return 0, errors.New("MemTotal not found in /proc/meminfo")
+}
+
+// NewAutoConfig creates a config with automatically detected memory.
+// It reads total system memory from /proc/meminfo, subtracts ReservedOSMemoryMB (4GB),
+// and aligns the result down to the nearest 2MB boundary.
+func NewAutoConfig() (*Config, error) {
+	totalMB, err := GetTotalSystemMemoryMB()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get total system memory: %w", err)
+	}
+
+	// Reserve 4GB for OS
+	availableMB := totalMB - ReservedOSMemoryMB
+	if availableMB <= 0 {
+		return nil, fmt.Errorf("insufficient memory after reserving %d MB for OS (total: %d MB)", ReservedOSMemoryMB, totalMB)
+	}
+
+	// Align down to 2MB boundary (hugepage size)
+	// Since hugepages are 2MB, ensure memory size is a multiple of 2MB
+	alignedMB := (availableMB / 2) * 2
+
+	// Ensure at least 1 hugepage (2MB) is available
+	if alignedMB < 2 {
+		return nil, fmt.Errorf("not enough memory for VM after alignment: %d MB", alignedMB)
+	}
+
+	return &Config{
+		MemMB:    alignedMB,
+		PageSize: HugepageSize2MB,
+	}, nil
+}
+
+// NewAutoConfig creates a config with automatically detected memory.
+// It reads total system memory from /proc/meminfo, subtracts ReservedOSMemoryMB (4GB),
+// and aligns the result down to the nearest 2MB boundary.
+func NewAutoConfig() (*Config, error) {
+	totalMB, err := GetTotalSystemMemoryMB()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get total system memory: %w", err)
+	}
+
+	// Reserve 4GB for OS
+	availableMB := totalMB - ReservedOSMemoryMB
+	if availableMB <= 0 {
+		return nil, fmt.Errorf("insufficient memory after reserving %d MB for OS (total: %d MB)", ReservedOSMemoryMB, totalMB)
+	}
+
+	// Align down to 2MB boundary (hugepage size)
+	// Since hugepages are 2MB, ensure memory size is a multiple of 2MB
+	alignedMB := (availableMB / 2) * 2
+
+	// Ensure at least 1 hugepage (2MB) is available
+	if alignedMB < 2 {
+		return nil, fmt.Errorf("not enough memory for VM after alignment: %d MB", alignedMB)
+	}
+
+	return &Config{
+		MemMB:    alignedMB,
+		PageSize: HugepageSize2MB,
+	}, nil
 }
 
 // RequiredPages returns the number of hugepages needed for the configured memory

--- a/internal/hugepages/hugepages.go
+++ b/internal/hugepages/hugepages.go
@@ -90,36 +90,6 @@ func NewAutoConfig() (*Config, error) {
 	}, nil
 }
 
-// NewAutoConfig creates a config with automatically detected memory.
-// It reads total system memory from /proc/meminfo, subtracts ReservedOSMemoryMB (4GB),
-// and aligns the result down to the nearest 2MB boundary.
-func NewAutoConfig() (*Config, error) {
-	totalMB, err := GetTotalSystemMemoryMB()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get total system memory: %w", err)
-	}
-
-	// Reserve 4GB for OS
-	availableMB := totalMB - ReservedOSMemoryMB
-	if availableMB <= 0 {
-		return nil, fmt.Errorf("insufficient memory after reserving %d MB for OS (total: %d MB)", ReservedOSMemoryMB, totalMB)
-	}
-
-	// Align down to 2MB boundary (hugepage size)
-	// Since hugepages are 2MB, ensure memory size is a multiple of 2MB
-	alignedMB := (availableMB / 2) * 2
-
-	// Ensure at least 1 hugepage (2MB) is available
-	if alignedMB < 2 {
-		return nil, fmt.Errorf("not enough memory for VM after alignment: %d MB", alignedMB)
-	}
-
-	return &Config{
-		MemMB:    alignedMB,
-		PageSize: HugepageSize2MB,
-	}, nil
-}
-
 // RequiredPages returns the number of hugepages needed for the configured memory
 func (c *Config) RequiredPages() int64 {
 	return (c.MemMB * 1024 * 1024) / c.PageSize

--- a/internal/hugepages/hugepages_test.go
+++ b/internal/hugepages/hugepages_test.go
@@ -2,6 +2,7 @@ package hugepages
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -109,5 +110,64 @@ func TestFormatError(t *testing.T) {
 	expected := "insufficient hugepages: have 1000, need 4096 (try: echo 4096 > /proc/sys/vm/nr_hugepages)"
 	if errMsg != expected {
 		t.Errorf("Expected error message %q, got %q", expected, errMsg)
+	}
+}
+
+func TestGetTotalSystemMemoryMB(t *testing.T) {
+	totalMB, err := GetTotalSystemMemoryMB()
+	if err != nil {
+		// Skip if /proc/meminfo not available (e.g., non-Linux)
+		if os.IsNotExist(err) {
+			t.Skip("/proc/meminfo not available")
+		}
+		t.Fatalf("GetTotalSystemMemoryMB failed: %v", err)
+	}
+
+	if totalMB <= 0 {
+		t.Errorf("Expected positive total memory, got %d", totalMB)
+	}
+
+	// Sanity check: total memory should be at least a few GB on modern systems
+	// Allow small embedded systems but warn
+	if totalMB < 1024 {
+		t.Logf("Warning: total memory (%d MB) seems low", totalMB)
+	}
+}
+
+func TestNewAutoConfig(t *testing.T) {
+	cfg, err := NewAutoConfig()
+	if err != nil {
+		// Skip if cannot read memory (non-Linux or no /proc/meminfo)
+		if os.IsNotExist(err) || strings.Contains(err.Error(), "failed to read /proc/meminfo") {
+			t.Skip("Cannot read /proc/meminfo: ", err)
+		}
+		t.Fatalf("NewAutoConfig failed: %v", err)
+	}
+
+	// Verify memory is reasonable
+	if cfg.MemMB <= 0 {
+		t.Errorf("Expected positive MemMB, got %d", cfg.MemMB)
+	}
+
+	// Verify page size is 2MB
+	if cfg.PageSize != HugepageSize2MB {
+		t.Errorf("Expected PageSize=%d, got %d", HugepageSize2MB, cfg.PageSize)
+	}
+
+	// Verify memory is aligned to 2MB boundary
+	if cfg.MemMB%2 != 0 {
+		t.Errorf("MemMB should be aligned to 2MB boundary, got %d", cfg.MemMB)
+	}
+
+	// Get total memory to verify reserve logic
+	totalMB, err := GetTotalSystemMemoryMB()
+	if err != nil {
+		t.Skip("Cannot verify reserve: cannot read total memory")
+	}
+
+	// VM memory should be <= total - 4GB (with alignment)
+	expectedMax := (totalMB - ReservedOSMemoryMB) / 2 * 2
+	if cfg.MemMB > expectedMax {
+		t.Errorf("MemMB (%d) exceeds expected max (%d) after reserving %d MB", cfg.MemMB, expectedMax, ReservedOSMemoryMB)
 	}
 }

--- a/internal/vm/vm_runner.go
+++ b/internal/vm/vm_runner.go
@@ -62,6 +62,7 @@ type VMRunner struct {
 	hostCPUTopology      models.HostCPUTopology
 	vcpuPinning          models.VCPUPinningGlobal
 	startStopScript      models.StartStopScript
+	memMB                int64 // Memory in MB for VM (dynamically allocated)
 }
 
 // NewVMRunner creates a new VM runner for the given VM
@@ -71,6 +72,7 @@ func NewVMRunner(vm *models.VM, cfg *config.Config) *VMRunner {
 		cfg:     cfg,
 		logChan: make(chan string, 256),
 		done:    make(chan struct{}),
+		memMB:   hugepages.DefaultMemoryMB, // default, overridden by Start()
 	}
 	if dryRunMode {
 		r.dryRun = true
@@ -172,8 +174,14 @@ func (r *VMRunner) Start() error {
 	}
 	r.mu.Unlock()
 
-	// Check hugepages availability for 8GB VM memory
-	hugepagesCfg := hugepages.NewConfig()
+	// Check hugepages availability for VM memory
+	hugepagesCfg, err := hugepages.NewAutoConfig()
+	if err != nil {
+		return fmt.Errorf("failed to configure VM memory: %w", err)
+	}
+	// Store memory size for QEMU args
+	r.memMB = hugepagesCfg.MemMB
+
 	result, err := hugepages.Check()
 	if err != nil {
 		return fmt.Errorf("hugepages check failed: %w", err)
@@ -186,9 +194,10 @@ func (r *VMRunner) Start() error {
 		result, err = hugepages.Ensure(hugepagesCfg)
 		if err != nil || !result.IsSufficient {
 			return fmt.Errorf(
-				"insufficient hugepages for VM %q: have %d pages (8GB × 2MB pages), need %d pages (try: echo %d > /proc/sys/vm/nr_hugepages)",
+				"insufficient hugepages for VM %q: have %d pages (%dMB × 2MB pages), need %d pages (try: echo %d > /proc/sys/vm/nr_hugepages)",
 				r.vm.Name,
 				result.AvailablePages,
+				r.memMB,
 				result.RequiredPages,
 				result.RequiredPages,
 			)

--- a/internal/vm/vm_runner_config.go
+++ b/internal/vm/vm_runner_config.go
@@ -98,9 +98,8 @@ func (r *VMRunner) buildQEMUArgs(vmDataDir string) []string {
 	}
 
 	// Hugepages
-	memMB := 8192 // Default 8GB
 	args = append(args,
-		"-object", fmt.Sprintf("memory-backend-memfd,id=mem,size=%dM,hugetlb=on,hugetlbsize=2M,prealloc=on", memMB),
+		"-object", fmt.Sprintf("memory-backend-memfd,id=mem,size=%dM,hugetlb=on,hugetlbsize=2M,prealloc=on", r.memMB),
 		"-machine", "memory-backend=mem",
 	)
 


### PR DESCRIPTION
Replace the hardcoded 8GB memory limit with a dynamic allocation system. The new logic reads total system memory from `/proc/meminfo`, reserves 4GB for the host OS, and aligns the remaining memory to a 2MB boundary to ensure compatibility with hugepages.

- Add `GetTotalSystemMemoryMB` to parse system memory
- Add `NewAutoConfig` to calculate available VM memory
- Update `VMRunner` to use dynamically detected memory in QEMU arguments
- Add unit tests for memory detection and configuration logic