### PR TITLE
fix(vm): run start script synchronously before QEMU launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Start script execution order**: Start/stop scripts now run synchronously before/after QEMU, ensuring VFIO devices are bound to `vfio-pci` before QEMU attempts passthrough
 - VM name input: spaces can now be typed in text fields
 - Multifunction PCI device address allocation for secondary functions
 - Silent failures and inconsistent error wrapping in OVMF file operations

--- a/internal/vm/vm_runner.go
+++ b/internal/vm/vm_runner.go
@@ -454,8 +454,11 @@ func (r *VMRunner) Start() error {
 		return err
 	}
 
-	// Execute start script asynchronously (non-blocking, errors logged to logChan)
-	go r.executeStartScriptAsync()
+	// Execute start script (blocking - must complete before QEMU starts
+	// so that PCI devices are bound to vfio-pci and /dev/vfio/* are available)
+	if err := r.executeStartScript(); err != nil {
+		return fmt.Errorf("start script failed: %w", err)
+	}
 
 	vmDataDir := r.getVMDataDir()
 	r.socketPath = filepath.Join("/tmp", fmt.Sprintf("dkvm-%s.sock", r.vm.ID))
@@ -952,18 +955,7 @@ func (r *VMRunner) executeStartScript() error {
 	return nil
 }
 
-// executeStartScriptAsync runs the start script in a goroutine without blocking
-func (r *VMRunner) executeStartScriptAsync() {
-	// Run in a goroutine to not block VM startup
-	go func() {
-		if err := r.executeStartScript(); err != nil {
-			// Error already logged to r.logChan by executeStartScript
-			if debugMode {
-				log.Printf("[DEBUG] start script (async) error: %v", err)
-			}
-		}
-	}()
-}
+
 
 // executeStopScript executes the stop script after QEMU exits (non-blocking)
 func (r *VMRunner) executeStopScript() {


### PR DESCRIPTION
The start script was launched asynchronously, causing QEMU to attempt VFIO device passthrough before PCI devices were bound to vfio-pci. This resulted in 'Could not open /dev/vfio/*: No such file or directory'.

Changed to a blocking call so the start script completes (binding devices to vfio-pci) before QEMU starts. Also removed the now-unused executeStartScriptAsync function.