### PR TITLE
style(tui): switch theme colors to 16-color ANSI palette

### DIFF
--- a/internal/tui/styles/colors_test.go
+++ b/internal/tui/styles/colors_test.go
@@ -13,14 +13,14 @@ func TestColorPalette(t *testing.T) {
 		color    lipgloss.Color
 		expected string
 	}{
-		{"Primary", Colors.Primary, "7aa2f7"},
-		{"Secondary", Colors.Secondary, "bb9af7"},
-		{"Success", Colors.Success, "73daca"},
-		{"Warning", Colors.Warning, "e0af68"},
-		{"Error", Colors.Error, "f7768e"},
-		{"Muted", Colors.Muted, "565f89"},
-		{"Background", Colors.Background, "#1a1b26"},
-		{"Border", Colors.Border, "#3b4261"},
+		{"Primary", Colors.Primary, "4"},
+		{"Secondary", Colors.Secondary, "5"},
+		{"Success", Colors.Success, "2"},
+		{"Warning", Colors.Warning, "3"},
+		{"Error", Colors.Error, "1"},
+		{"Muted", Colors.Muted, "8"},
+		{"Background", Colors.Background, "0"},
+		{"Border", Colors.Border, "8"},
 	}
 
 	for _, tt := range tests {
@@ -38,9 +38,9 @@ func TestStatusColors(t *testing.T) {
 		color    lipgloss.Color
 		expected string
 	}{
-		{"Running", StatusColors.Running, "73daca"},
-		{"Stopped", StatusColors.Stopped, "565f89"},
-		{"Error", StatusColors.Error, "f7768e"},
+		{"Running", StatusColors.Running, "2"},
+		{"Stopped", StatusColors.Stopped, "8"},
+		{"Error", StatusColors.Error, "1"},
 	}
 
 	for _, tt := range tests {

--- a/internal/tui/theme/contrast.go
+++ b/internal/tui/theme/contrast.go
@@ -16,8 +16,32 @@ type ContrastResult struct {
 	Level       string // "AA" or "AAA"
 }
 
-// hexToRGB converts a hex color string (#RRGGBB) to RGB components (0-255).
+// ansi16Colors maps the 16 ANSI color codes to approximate RGB values.
+var ansi16Colors = map[string][3]uint8{
+	"0":  {0x00, 0x00, 0x00}, // Black
+	"1":  {0x80, 0x00, 0x00}, // Red
+	"2":  {0x00, 0x80, 0x00}, // Green
+	"3":  {0x80, 0x80, 0x00}, // Yellow
+	"4":  {0x00, 0x00, 0x80}, // Blue
+	"5":  {0x80, 0x00, 0x80}, // Magenta
+	"6":  {0x00, 0x80, 0x80}, // Cyan
+	"7":  {0xc0, 0xc0, 0xc0}, // White (light gray)
+	"8":  {0x80, 0x80, 0x80}, // Bright Black (dark gray)
+	"9":  {0xff, 0x00, 0x00}, // Bright Red
+	"10": {0x00, 0xff, 0x00}, // Bright Green
+	"11": {0xff, 0xff, 0x00}, // Bright Yellow
+	"12": {0x00, 0x00, 0xff}, // Bright Blue
+	"13": {0xff, 0x00, 0xff}, // Bright Magenta
+	"14": {0x00, 0xff, 0xff}, // Bright Cyan
+	"15": {0xff, 0xff, 0xff}, // Bright White
+}
+
+// hexToRGB converts a hex color string (#RRGGBB) or ANSI code (0-15) to RGB components (0-255).
 func hexToRGB(hex string) (r, g, b uint8) {
+	// Check if it's an ANSI 16-color code
+	if rgb, ok := ansi16Colors[hex]; ok {
+		return rgb[0], rgb[1], rgb[2]
+	}
 	if len(hex) != 7 || hex[0] != '#' {
 		return 0, 0, 0
 	}

--- a/internal/tui/theme/theme.go
+++ b/internal/tui/theme/theme.go
@@ -28,54 +28,55 @@ type Theme struct {
 	HoverBackground lipgloss.Color // Background on hover/focus
 }
 
-// NewDarkTheme creates a theme suitable for dark terminals.
+// NewDarkTheme creates a theme suitable for dark terminals in pure textmode.
+// All colors use the 16-color ANSI palette (0-15) for maximum compatibility.
 func NewDarkTheme() Theme {
 	return Theme{
-		Primary:         lipgloss.Color("#7aa2f7"), // Blue (Storm)
-		PrimaryDim:      lipgloss.Color("#292e42"), // Blue-tinted dark
-		Secondary:       lipgloss.Color("#bb9af7"), // Purple
-		SecondaryDim:    lipgloss.Color("#2a2e3f"), // Purple-tinted dark
-		Success:         lipgloss.Color("#73daca"), // Teal green
-		SuccessDim:      lipgloss.Color("#1a1f2e"), // Subtle green tint
-		Warning:         lipgloss.Color("#e0af68"), // Orange/yellow
-		WarningDim:      lipgloss.Color("#2f1f1a"), // Subtle yellow tint
-		Error:           lipgloss.Color("#f7768e"), // Red pink
-		ErrorDim:        lipgloss.Color("#2f1a1f"), // Subtle red tint
-		Foreground:      lipgloss.Color("#a9b1d6"), // Foreground (light gray-blue)
-		ForegroundDim:   lipgloss.Color("#828baa"), // Dimmed text (blue-gray, WCAG AA: 5.06:1 on bg)
-		Muted:           lipgloss.Color("#828baa"), // Muted blue-gray (WCAG AA: 5.06:1 on bg)
-		Background:      lipgloss.Color("#1a1b26"), // Deep navy
-		Border:          lipgloss.Color("#626e98"), // Muted blue (WCAG AA 1.4.11: 3.42:1 on bg)
-		FocusedBackground: lipgloss.Color("#1f2335"), // Lighter navy
-		UnfocusedBackground: lipgloss.Color("#16161e"), // Darker navy
-		FocusBorder:     lipgloss.Color("#7aa2f7"), // Same as Primary
-		HoverBackground: lipgloss.Color("#1f2335"), // Same as FocusedBackground
+		Primary:         lipgloss.Color("4"),  // Blue
+		PrimaryDim:      lipgloss.Color("12"), // Bright blue
+		Secondary:       lipgloss.Color("5"),  // Magenta
+		SecondaryDim:    lipgloss.Color("13"), // Bright magenta
+		Success:         lipgloss.Color("2"),  // Green
+		SuccessDim:      lipgloss.Color("10"), // Bright green
+		Warning:         lipgloss.Color("3"),  // Yellow
+		WarningDim:      lipgloss.Color("11"), // Bright yellow
+		Error:           lipgloss.Color("1"),  // Red
+		ErrorDim:        lipgloss.Color("9"),  // Bright red
+		Foreground:      lipgloss.Color("7"),  // Light gray
+		ForegroundDim:   lipgloss.Color("8"),  // Dark gray
+		Muted:           lipgloss.Color("8"),  // Dark gray
+		Background:      lipgloss.Color("0"),  // Black
+		Border:          lipgloss.Color("8"),  // Dark gray
+		FocusedBackground: lipgloss.Color("0"), // Black
+		UnfocusedBackground: lipgloss.Color("0"), // Black
+		FocusBorder:     lipgloss.Color("4"),  // Blue (same as Primary)
+		HoverBackground: lipgloss.Color("0"),  // Black
 	}
 }
 
-// NewLightTheme creates a theme suitable for light terminals (if needed).
-// All color combinations are verified to meet WCAG AA 4.5:1 contrast ratio.
+// NewLightTheme creates a theme suitable for light terminals in pure textmode.
+// All colors use the 16-color ANSI palette (0-15) for maximum compatibility.
 func NewLightTheme() Theme {
 	return Theme{
-		Primary:         lipgloss.Color("#2f6dde"), // Blue
-		PrimaryDim:      lipgloss.Color("#f6f8fc"), // Very light blue tint (WCAG AA section headers)
-		Secondary:       lipgloss.Color("#7c3aed"), // Purple (5.70:1 on white)
-		SecondaryDim:    lipgloss.Color("#ede9fe"), // Light purple tint
-		Success:         lipgloss.Color("#15803d"), // Green (5.02:1 on white)
-		SuccessDim:      lipgloss.Color("#dcfce7"), // Light green tint (4.57:1 with success text)
-		Warning:         lipgloss.Color("#a16207"), // Amber (4.92:1 on white)
-		WarningDim:      lipgloss.Color("#fef9c3"), // Light amber tint (4.58:1 with warning text)
-		Error:           lipgloss.Color("#c53030"), // Red
-		ErrorDim:        lipgloss.Color("#fef2f2"), // Light red tint (5.00:1 with error text)
-		Foreground:      lipgloss.Color("#212529"), // Dark gray for text
-		ForegroundDim:   lipgloss.Color("#5f6878"), // Gray (5.62:1 on white, WCAG AA on all bg variants)
-		Muted:           lipgloss.Color("#5f6878"), // Gray (5.62:1 on white, WCAG AA on all bg variants)
-		Background:      lipgloss.Color("#ffffff"), // White
-		Border:          lipgloss.Color("#6b7280"), // Gray border (4.83:1 on white, WCAG 1.4.11)
-		FocusedBackground: lipgloss.Color("#f8f9fa"), // Light gray
-		UnfocusedBackground: lipgloss.Color("#e9ecef"), // Slightly lighter gray
-		FocusBorder:     lipgloss.Color("#2f6dde"), // Same as Primary
-		HoverBackground: lipgloss.Color("#f8f9fa"), // Same as FocusedBackground (WCAG AA for text on hover)
+		Primary:         lipgloss.Color("4"),  // Blue
+		PrimaryDim:      lipgloss.Color("12"), // Bright blue
+		Secondary:       lipgloss.Color("5"),  // Magenta
+		SecondaryDim:    lipgloss.Color("13"), // Bright magenta
+		Success:         lipgloss.Color("2"),  // Green
+		SuccessDim:      lipgloss.Color("10"), // Bright green
+		Warning:         lipgloss.Color("3"),  // Yellow
+		WarningDim:      lipgloss.Color("11"), // Bright yellow
+		Error:           lipgloss.Color("1"),  // Red
+		ErrorDim:        lipgloss.Color("9"),  // Bright red
+		Foreground:      lipgloss.Color("0"),  // Black
+		ForegroundDim:   lipgloss.Color("8"),  // Dark gray
+		Muted:           lipgloss.Color("8"),  // Dark gray
+		Background:      lipgloss.Color("15"), // White
+		Border:          lipgloss.Color("8"),  // Dark gray
+		FocusedBackground: lipgloss.Color("15"), // White
+		UnfocusedBackground: lipgloss.Color("7"), // Light gray
+		FocusBorder:     lipgloss.Color("4"),  // Blue (same as Primary)
+		HoverBackground: lipgloss.Color("15"), // White
 	}
 }
 


### PR DESCRIPTION
Replace hex color codes with ANSI 16-color codes in the dark and light themes to ensure maximum compatibility across different terminal emulators. Update the contrast checker to support ANSI color code resolution to RGB.