### PR TITLE
feat(tui): improve VM startup with async execution and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.1](https://github.com/glemsom/dkvmmanager/compare/v0.1.0...v0.1.1) (2026-04-28)
-
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent TUI freeze during VM startup by running `runner.Start()` in a goroutine instead of blocking the BubbleTea event loop
+
 ## [0.1.3](https://github.com/glemsom/dkvmmanager/compare/v0.1.2...v0.1.3) (2026-04-30)
 
 ### Added

--- a/internal/tui/models/key_handlers.go
+++ b/internal/tui/models/key_handlers.go
@@ -95,6 +95,17 @@ func (m *MainModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Handle VM start failure from async start command
+	if vse, ok := msg.(VMStartErrorMsg); ok {
+		m.statusBar.SetMessage("Error starting VM: " + vse.Err.Error())
+		m.runningVMID = ""
+		m.vmRunningModel = nil
+		m.currentView = ViewMainMenu
+		m.rebuildMenuList()
+		m.breadcrumbs.Clear()
+		return m, nil
+	}
+
 	// Handle exit request from VM running view
 	if _, ok := msg.(VMRunningViewExitMsg); ok {
 		return m.returnFromSubView()
@@ -596,20 +607,10 @@ func (m *MainModel) handleVMSelection() (tea.Model, tea.Cmd) {
 		if hostTopo, err := m.vmManager.ScanCPUTopology(); err == nil {
 			runner.SetHostCPUTopology(hostTopo)
 		}
-		if err := runner.Start(); err != nil {
-			m.statusBar.SetMessage("Error starting VM: " + err.Error())
-			return m, nil
-		}
 
-		// Update status bar to show this VM is running
-		m.statusBar.SetStats(len(m.menuItems), 1)
-		
-		// Track the running VM ID so status bar count survives rebuildMenuList
-		m.runningVMID = vmObj.ID
-
-		// Create running model
-		m.vmRunningModel = NewVMRunningModel(vmObj, runner)
-		m.vmRunningModel.startTime = time.Now() // Set before SetSize so uptime displays immediately
+		// Create running model immediately (runner will be set async)
+		m.vmRunningModel = NewVMRunningModel(vmObj, nil) // nil runner
+		m.vmRunningModel.startTime = time.Now()
 		m.vmRunningModel.SetSize(m.windowWidth-4, m.contentHeight()-2)
 		m.currentView = ViewVMRunning
 		m.breadcrumbs.Clear()
@@ -617,11 +618,19 @@ func (m *MainModel) handleVMSelection() (tea.Model, tea.Cmd) {
 		m.breadcrumbs.AddItem("Start", "vm_start", 1)
 		m.breadcrumbs.AddItem(vmObj.Name, "vm_running", 1)
 
+		// Optimistically update status bar
+		m.statusBar.SetStats(len(m.menuItems), 1)
+		m.runningVMID = vmObj.ID
+
+		// Start VM asynchronously — view is already visible
 		if debugMode {
-			log.Printf("[DEBUG] VM started: %s (ID: %s)", vmObj.Name, vmObj.ID)
+			log.Printf("[DEBUG] VM starting async: %s (ID: %s)", vmObj.Name, vmObj.ID)
 		}
 
-		return m, m.vmRunningModel.Init()
+		return m, tea.Batch(
+			m.vmRunningModel.Init(),               // polls with nil runner → shows "[STARTING]"
+			startVMCommand(runner, vmObj.Name, vmObj.ID),
+		)
 	}
 	return m, nil
 }

--- a/internal/tui/models/vm_running.go
+++ b/internal/tui/models/vm_running.go
@@ -539,13 +539,17 @@ func (m *VMRunningModel) Runner() *vm.VMRunner {
 	return m.runner
 }
 
-// startVMCommand returns a tea.Cmd that runs runner.Start() in a goroutine.
+// startVMCommand returns a tea.Cmd that runs runner.Start() in a goroutine
+// to avoid blocking the BubbleTea event loop during VM startup.
 // Sends VMStartedMsg on success, VMStartErrorMsg on failure.
 func startVMCommand(runner *vm.VMRunner, vmName, vmID string) tea.Cmd {
-	return func() tea.Msg {
+	ch := make(chan tea.Msg, 1)
+	go func() {
 		if err := runner.Start(); err != nil {
-			return VMStartErrorMsg{VMName: vmName, Err: err}
+			ch <- VMStartErrorMsg{VMName: vmName, Err: err}
+		} else {
+			ch <- VMStartedMsg{Runner: runner, VMName: vmName, VMID: vmID}
 		}
-		return VMStartedMsg{Runner: runner, VMName: vmName, VMID: vmID}
-	}
+	}()
+	return func() tea.Msg { return <-ch }
 }

--- a/internal/tui/models/vm_running.go
+++ b/internal/tui/models/vm_running.go
@@ -16,8 +16,15 @@ import (
 
 // VMStartedMsg is sent when a VM starts successfully
 type VMStartedMsg struct {
+	Runner *vm.VMRunner
 	VMName string
 	VMID   string
+}
+
+// VMStartErrorMsg is sent when a VM fails to start
+type VMStartErrorMsg struct {
+	VMName string
+	Err    error
 }
 
 // VMStoppedMsg is sent when a VM stops
@@ -113,9 +120,9 @@ func (m *VMRunningModel) initialStatus() tea.Cmd {
 // waitForLog returns a tea.Cmd that reads one log line from the runner
 func (m *VMRunningModel) waitForLog() tea.Cmd {
 	return func() tea.Msg {
-		// Guard against nil runner and nil channel
+		// Guard against nil runner
 		if m.runner == nil {
-			return VMLogMsg{Line: ""}
+			return nil // no-op until runner is set
 		}
 
 		line, ok := <-m.runner.LogChan()
@@ -131,11 +138,7 @@ func (m *VMRunningModel) waitForVMExit() tea.Cmd {
 	return func() tea.Msg {
 		// Guard against nil runner
 		if m.runner == nil {
-			return VMStoppedMsg{
-				VMName: m.vm.Name,
-				VMID:   m.vm.ID,
-				Reason: "no runner",
-			}
+			return nil // no-op until runner is set
 		}
 
 		<-m.runner.Done()
@@ -219,6 +222,16 @@ func (m *VMRunningModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.status = msg.Status
 		m.threads = msg.Threads
 		return m, m.pollStatus()
+
+	case VMStartedMsg:
+		m.runner = msg.Runner
+		m.status = "starting" // will be updated by initialStatus
+		return m, tea.Batch(
+			m.waitForLog(),
+			m.waitForVMExit(),
+			m.pollStatus(),
+			m.initialStatus(),
+		)
 	}
 
 	return m, nil
@@ -524,4 +537,15 @@ func (m *VMRunningModel) SetSize(w, h int) {
 // Runner returns the underlying VM runner
 func (m *VMRunningModel) Runner() *vm.VMRunner {
 	return m.runner
+}
+
+// startVMCommand returns a tea.Cmd that runs runner.Start() in a goroutine.
+// Sends VMStartedMsg on success, VMStartErrorMsg on failure.
+func startVMCommand(runner *vm.VMRunner, vmName, vmID string) tea.Cmd {
+	return func() tea.Msg {
+		if err := runner.Start(); err != nil {
+			return VMStartErrorMsg{VMName: vmName, Err: err}
+		}
+		return VMStartedMsg{Runner: runner, VMName: vmName, VMID: vmID}
+	}
 }

--- a/internal/tui/models/vm_running_test.go
+++ b/internal/tui/models/vm_running_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	models "github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/vm"
 )
 
 func setupRunningModel(t *testing.T, status string) *VMRunningModel {
@@ -456,5 +457,101 @@ func TestVMRunningModelViewNoThreadsWhenEmpty(t *testing.T) {
 	view := m.View()
 	if strings.Contains(view, "vCPU Threads:") {
 		t.Error("View should not show 'vCPU Threads:' when threads empty")
+	}
+}
+
+// --- Async VM Start Tests ---
+
+func TestVMStartedMsgHandlerSetsRunner(t *testing.T) {
+	m := setupRunningModel(t, "starting")
+
+	// Create a real runner (with nil config, not used in this test)
+	runner := vm.NewVMRunner(&models.VM{Name: "test-vm", ID: "1"}, nil)
+
+	// Simulate receiving VMStartedMsg with a runner
+	msg := VMStartedMsg{
+		Runner: runner,
+		VMName: "test-vm",
+		VMID:   "1",
+	}
+	updated, cmd := m.Update(msg)
+	m = updated.(*VMRunningModel)
+
+	if m.runner == nil {
+		t.Error("Expected runner to be set after VMStartedMsg")
+	}
+	if m.status != "starting" {
+		t.Errorf("Expected status 'starting', got '%s'", m.status)
+	}
+	if cmd == nil {
+		t.Error("Expected non-nil command after VMStartedMsg")
+	}
+}
+
+func TestVMStartErrorMsgHandler(t *testing.T) {
+	// VMStartErrorMsg is handled by the parent MainModel, not VMRunningModel.
+	// This test verifies the message type exists and carries the expected data.
+	expectedErr := fmt.Errorf("QEMU not found")
+	errMsg := VMStartErrorMsg{
+		VMName: "test-vm",
+		Err:    expectedErr,
+	}
+
+	if errMsg.VMName != "test-vm" {
+		t.Errorf("Expected VMName 'test-vm', got '%s'", errMsg.VMName)
+	}
+	if errMsg.Err.Error() != expectedErr.Error() {
+		t.Errorf("Expected error '%v', got '%v'", expectedErr, errMsg.Err)
+	}
+}
+
+func TestStartVMCommandSuccess(t *testing.T) {
+	// startVMCommand takes a *vm.VMRunner and calls .Start() which launches
+	// real processes (QEMU, swtpm, etc.), making it unsuitable for unit tests.
+	// The logic is verified indirectly via integration tests and the
+	// VMStartedMsg handler test above.
+	// This test confirms the function signature is correct and compiles.
+	var _ func(runner *vm.VMRunner, vmName, vmID string) tea.Cmd = startVMCommand
+}
+
+func TestNilRunnerWaitForLogReturnsNil(t *testing.T) {
+	// When runner is nil, waitForLog should return nil (no-op),
+	// not an empty VMLogMsg.
+	m := setupRunningModel(t, "starting")
+	// Ensure runner is nil
+	if m.runner != nil {
+		t.Fatal("Expected nil runner in setupRunningModel")
+	}
+
+	// Execute the waitForLog command
+	cmd := m.waitForLog()
+	if cmd == nil {
+		t.Fatal("waitForLog should return a non-nil tea.Cmd")
+	}
+
+	msg := cmd()
+	if msg != nil {
+		t.Errorf("Expected nil message when runner is nil, got %T: %v", msg, msg)
+	}
+}
+
+func TestNilRunnerWaitForVMExitReturnsNil(t *testing.T) {
+	// When runner is nil, waitForVMExit should return nil (no-op),
+	// not a VMStoppedMsg.
+	m := setupRunningModel(t, "starting")
+	// Ensure runner is nil
+	if m.runner != nil {
+		t.Fatal("Expected nil runner in setupRunningModel")
+	}
+
+	// Execute the waitForVMExit command
+	cmd := m.waitForVMExit()
+	if cmd == nil {
+		t.Fatal("waitForVMExit should return a non-nil tea.Cmd")
+	}
+
+	msg := cmd()
+	if msg != nil {
+		t.Errorf("Expected nil message when runner is nil, got %T: %v", msg, msg)
 	}
 }


### PR DESCRIPTION
Extract startVMCommand to run VM start asynchronously. Show '[STARTING]' status while VM boots. Add VMStartErrorMsg type for structured error reporting to the status bar. Add tests for new startup flow.

## Description

<!-- Briefly describe what this PR changes and why. -->

## Type of change

<!-- Check the box that applies. This helps generate changelog entries. -->

- [ ] `feat` — New feature (will appear in "Added" section)
- [x] `fix` — Bug fix (will appear in "Fixed" section)
- [ ] `refactor` — Code refactoring (no user-facing change)
- [ ] `docs` — Documentation only
- [ ] `test` — Test additions or fixes
- [ ] `ci` — CI/CD configuration
- [ ] `chore` — Other maintenance

## Conventional Commit title

<!-- Write a Conventional-Commit-style title for this PR. Example:
     feat: add striped LVM support in configuration dialog
     fix: resolve silent failure in OVMF file operations -->

```
<type>[optional scope]: <short description>
```

## Checklist

- [ ] Tests pass locally (`make test`)
- [ ] Code builds without errors (`make build`)
- [ ] CHANGELOG.md updated if this change won't be auto-detected
- [ ] Commit messages follow Conventional Commits format
