### PR TITLE
fix(pci-passthrough): remount /media/usb rw before updating grub.cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Fixed
--
+- **PCI passthrough Apply to Kernel**: Remount `/media/usb` as `rw` before modifying `grub.cfg` and restore to `ro` afterward, since DKVM Hypervisor keeps the USB filesystem read-only by default (`internal/vm/manager.go`)
 
 ### Security
 -

--- a/internal/vm/grub_config.go
+++ b/internal/vm/grub_config.go
@@ -25,7 +25,7 @@ func BuildVFIOIDs(devices []models.PCIPassthroughDevice) string {
 
 // UpdateGrubVFIOIDs updates the vfio-pci.ids parameter in the grub.cfg file.
 // It creates a backup before modification and writes the updated content.
-// The caller is responsible for ensuring the filesystem is writable (remounted rw).
+// The caller must ensure the filesystem is writable (e.g., remounted rw for /media/usb).
 func UpdateGrubVFIOIDs(vfioIDs, grubPath string) error {
 	// Debug logging
 	if debugMode {
@@ -91,7 +91,7 @@ func UpdateGrubVFIOIDs(vfioIDs, grubPath string) error {
 		newContent = replaced
 	}
 
-	// 4. Write back (requires rw mount on /media/usb)
+	// 4. Write back
 	if err := os.WriteFile(grubPath, []byte(newContent), 0644); err != nil {
 		if debugMode {
 			log.Printf("[DEBUG] UpdateGrubVFIOIDs: failed to write updated grub.cfg: %v", err)

--- a/internal/vm/grub_config.go
+++ b/internal/vm/grub_config.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"regexp"
 	"strings"
@@ -26,16 +27,35 @@ func BuildVFIOIDs(devices []models.PCIPassthroughDevice) string {
 // It creates a backup before modification and writes the updated content.
 // The caller is responsible for ensuring the filesystem is writable (remounted rw).
 func UpdateGrubVFIOIDs(vfioIDs, grubPath string) error {
+	// Debug logging
+	if debugMode {
+		log.Printf("[DEBUG] UpdateGrubVFIOIDs: grubPath=%s, vfioIDs=%q", grubPath, vfioIDs)
+	}
+
 	// 1. Read current content
 	content, err := os.ReadFile(grubPath)
 	if err != nil {
+		if debugMode {
+			log.Printf("[DEBUG] UpdateGrubVFIOIDs: failed to read grub.cfg: %v", err)
+		}
 		return fmt.Errorf("read grub.cfg: %w", err)
+	}
+
+	if debugMode {
+		log.Printf("[DEBUG] UpdateGrubVFIOIDs: read %d bytes from %s", len(content), grubPath)
 	}
 
 	// 2. Backup existing file
 	backupPath := grubPath + ".bak"
 	if err := os.WriteFile(backupPath, content, 0644); err != nil {
+		if debugMode {
+			log.Printf("[DEBUG] UpdateGrubVFIOIDs: failed to create backup: %v", err)
+		}
 		return fmt.Errorf("backup grub.cfg: %w", err)
+	}
+
+	if debugMode {
+		log.Printf("[DEBUG] UpdateGrubVFIOIDs: backup created at %s", backupPath)
 	}
 
 	// 3. Modify content using regex
@@ -47,6 +67,9 @@ func UpdateGrubVFIOIDs(vfioIDs, grubPath string) error {
 		// Remove the parameter if empty (clean up trailing space too)
 		reWithSpace := regexp.MustCompile(`\s*vfio-pci\.ids=[^\s]+`)
 		newContent = reWithSpace.ReplaceAllString(string(content), "")
+		if debugMode {
+			log.Printf("[DEBUG] UpdateGrubVFIOIDs: removed vfio-pci.ids parameter (was empty)")
+		}
 	} else {
 		// Replace existing or add new
 		replaced := re.ReplaceAllString(string(content), fmt.Sprintf("vfio-pci.ids=%s", vfioIDs))
@@ -57,10 +80,28 @@ func UpdateGrubVFIOIDs(vfioIDs, grubPath string) error {
 			// Use (?m) for multiline mode so ^ matches start of each line
 			linuxLineRe := regexp.MustCompile(`(?m)^[\t ]*linux[^\n]*`)
 			replaced = linuxLineRe.ReplaceAllString(string(content), fmt.Sprintf("$0 vfio-pci.ids=%s", vfioIDs))
+			if debugMode {
+				log.Printf("[DEBUG] UpdateGrubVFIOIDs: added new vfio-pci.ids parameter to linux line")
+			}
+		} else {
+			if debugMode {
+				log.Printf("[DEBUG] UpdateGrubVFIOIDs: replaced existing vfio-pci.ids parameter")
+			}
 		}
 		newContent = replaced
 	}
 
 	// 4. Write back (requires rw mount on /media/usb)
-	return os.WriteFile(grubPath, []byte(newContent), 0644)
+	if err := os.WriteFile(grubPath, []byte(newContent), 0644); err != nil {
+		if debugMode {
+			log.Printf("[DEBUG] UpdateGrubVFIOIDs: failed to write updated grub.cfg: %v", err)
+		}
+		return err
+	}
+
+	if debugMode {
+		log.Printf("[DEBUG] UpdateGrubVFIOIDs: successfully updated %s", grubPath)
+	}
+
+	return nil
 }

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"time"
@@ -225,14 +226,32 @@ func (m *Manager) SaveStartStopScript(cfg models.StartStopScript) error {
 // vfio-pci.ids parameter string, and writes it to the grub.cfg file.
 // It returns an error if the config cannot be read, or the grub.cfg cannot be updated.
 func (m *Manager) ApplyVFIOIDsToKernel() error {
+	if debugMode {
+		log.Println("[DEBUG] ApplyVFIOIDsToKernel: starting")
+	}
+
 	// Get current PCI passthrough config
 	pciCfg, err := m.GetPCIPassthroughConfig()
 	if err != nil {
+		if debugMode {
+			log.Printf("[DEBUG] ApplyVFIOIDsToKernel: failed to get PCI config: %v", err)
+		}
 		return fmt.Errorf("get PCI passthrough config: %w", err)
+	}
+
+	if debugMode {
+		log.Printf("[DEBUG] ApplyVFIOIDsToKernel: got %d PCI devices from config", len(pciCfg.Devices))
+		for i, dev := range pciCfg.Devices {
+			log.Printf("[DEBUG] ApplyVFIOIDsToKernel: device[%d] = %s:%s (%s)", i, dev.Vendor, dev.Device, dev.Address)
+		}
 	}
 
 	// Build vfio-pci.ids string
 	vfioIDs := BuildVFIOIDs(pciCfg.Devices)
+
+	if debugMode {
+		log.Printf("[DEBUG] ApplyVFIOIDsToKernel: built vfioIDs = %q", vfioIDs)
+	}
 
 	// Get grub config path
 	grubPath := m.cfg.GrubConfigPath
@@ -240,11 +259,21 @@ func (m *Manager) ApplyVFIOIDsToKernel() error {
 		grubPath = "/media/usb/boot/grub/grub.cfg"
 	}
 
+	if debugMode {
+		log.Printf("[DEBUG] ApplyVFIOIDsToKernel: grubPath = %s", grubPath)
+	}
+
 	// Update grub.cfg
 	if err := UpdateGrubVFIOIDs(vfioIDs, grubPath); err != nil {
+		if debugMode {
+			log.Printf("[DEBUG] ApplyVFIOIDsToKernel: UpdateGrubVFIOIDs failed: %v", err)
+		}
 		return fmt.Errorf("update grub.cfg: %w", err)
 	}
 
+	if debugMode {
+		log.Println("[DEBUG] ApplyVFIOIDsToKernel: completed successfully")
+	}
 	return nil
 }
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/glemsom/dkvmmanager/internal/config"
@@ -263,6 +265,21 @@ func (m *Manager) ApplyVFIOIDsToKernel() error {
 		log.Printf("[DEBUG] ApplyVFIOIDsToKernel: grubPath = %s", grubPath)
 	}
 
+	// Remount /media/usb as rw before modifying grub.cfg.
+	// DKVM Hypervisor keeps the USB filesystem read-only by default.
+	remountPath := detectMountPath(grubPath)
+	if remountPath != "" {
+		if err := remountFilesystem(remountPath, "rw"); err != nil {
+			return fmt.Errorf("remount %s as rw: %w", remountPath, err)
+		}
+		// Always restore read-only after the update, regardless of outcome.
+		defer func() {
+			if err := remountFilesystem(remountPath, "ro"); err != nil {
+				log.Printf("[WARN] ApplyVFIOIDsToKernel: failed to remount %s as ro: %v", remountPath, err)
+			}
+		}()
+	}
+
 	// Update grub.cfg
 	if err := UpdateGrubVFIOIDs(vfioIDs, grubPath); err != nil {
 		if debugMode {
@@ -342,4 +359,30 @@ func generateMAC() string {
 	bytes[0] = bytes[0]&0xFE | 0x02
 	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x",
 		bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5])
+}
+
+// detectMountPath checks if a file path resides under /media/usb and returns
+// the mount point path, or an empty string if no remount is needed.
+func detectMountPath(filePath string) string {
+	if strings.HasPrefix(filePath, "/media/usb") {
+		return "/media/usb"
+	}
+	return ""
+}
+
+// remountFilesystem remounts the given mount point with the specified options
+// (e.g., "rw" or "ro"). It uses the mount command with the remount flag.
+func remountFilesystem(mountPath, mode string) error {
+	if debugMode {
+		log.Printf("[DEBUG] remountFilesystem: mount -o remount,%s %s", mode, mountPath)
+	}
+	cmd := exec.Command("mount", "-o", "remount,"+mode, mountPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("mount -o remount,%s %s: %s: %w", mode, mountPath, string(output), err)
+	}
+	if debugMode {
+		log.Printf("[DEBUG] remountFilesystem: successfully remounted %s as %s", mountPath, mode)
+	}
+	return nil
 }


### PR DESCRIPTION
**What this fixes**

DKVM Hypervisor keeps `/media/usb` mounted read-only by default, causing `grub.cfg` writes to fail silently when applying `vfio-pci.ids` kernel arguments from the PCI Passthrough → Apply to Kernel flow.

**Changes**

- `internal/vm/manager.go` — `ApplyVFIOIDsToKernel()` now remounts `/media/usb` as `rw` before modifying `grub.cfg` and restores it to `ro` afterward (via `defer`). Only triggers when grub.cfg path is under `/media/usb`.
- `internal/vm/grub_config.go` — updated doc comment to reflect caller handles writability.
- `CHANGELOG.md` — documented fix under `[Unreleased] → Fixed`.

**Commits**

- `a070907` fix(pci-passthrough): remount /media/usb rw before updating grub.cfg
- `188bdf8` refactor(vm): add debug logging to VFIO kernel commandline functions