### PR TITLE
feat(tui): warn when /media/dkvmdata is not a mount point

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,0 @@
-# TODO
- - Add support for setting kernel arguments for vCPU optimization
-   - isolcpus=domain,managed_irq=VM CPUs
-   - nohz_full=VM CPUs
-   - rcu_nocbs=VM CPUs
-
-- Add support for setting vfio-pci.ids kernel parameter
-  - vfio-pci.ids=passhtrough PCI devices

--- a/internal/tui/models/init.go
+++ b/internal/tui/models/init.go
@@ -33,6 +33,21 @@ func NewMainModelWithConfig(cfg *config.Config) (*MainModel, error) {
 		log.Printf("[DEBUG] MainModel created with %d menu items", len(menuItems))
 	}
 
+	// Check if /media/dkvmdata is a mount point
+	initialView := ViewMainMenu
+	var mountPointWarningModel *MountPointWarningModel
+	if mounted, err := isMountPoint(dkvmDataMountPath); err == nil && !mounted {
+		if debugMode {
+			log.Printf("[DEBUG] %s is not a mount point, showing warning", dkvmDataMountPath)
+		}
+		initialView = ViewMountPointWarning
+		mountPointWarningModel = NewMountPointWarningModel()
+	} else if err != nil {
+		if debugMode {
+			log.Printf("[DEBUG] Error checking mount point %s: %v", dkvmDataMountPath, err)
+		}
+	}
+
 	// Initialize menu list
 	menuListAdapter := buildMenuListAdapter(menuItems)
 	delegate := MenuItemDelegate{}
@@ -72,18 +87,19 @@ func NewMainModelWithConfig(cfg *config.Config) (*MainModel, error) {
 	breadcrumbs := components.NewBreadcrumbs()
 
 	return &MainModel{
-		currentView:   ViewMainMenu,
-		cfg:           cfg,
-		vmManager:     vmMgr,
-		selectedIndex: 0,
-		menuItems:     menuItems,
-		menuList:      menuList,
-		configList:    configList,
-		powerList:     powerList,
-		debugMode:     debugMode,
-		tabModel:      tabModel,
-		statusBar:     statusBar,
-		breadcrumbs:   breadcrumbs,
+		currentView:            initialView,
+		cfg:                    cfg,
+		vmManager:              vmMgr,
+		selectedIndex:          0,
+		menuItems:              menuItems,
+		menuList:               menuList,
+		configList:             configList,
+		powerList:              powerList,
+		debugMode:              debugMode,
+		tabModel:               tabModel,
+		statusBar:              statusBar,
+		breadcrumbs:            breadcrumbs,
+		mountPointWarningModel: mountPointWarningModel,
 	}, nil
 }
 

--- a/internal/tui/models/key_handlers.go
+++ b/internal/tui/models/key_handlers.go
@@ -578,7 +578,7 @@ func (m *MainModel) handlePowerSelection() (tea.Model, tea.Cmd) {
 // isSubViewActive returns true if a sub-view (create/edit/delete/select/running) is active
 func (m *MainModel) isSubViewActive() bool {
 	switch m.currentView {
-	case ViewVMCreate, ViewVMEdit, ViewVMDelete, ViewVMSelect, ViewCPUOptions, ViewVMRunning, ViewPCIPassthrough, ViewUSBPassthrough, ViewCPUTopology, ViewVCPUPinning, ViewSSHPassword, ViewStartStopScript, ViewLVCreate:
+	case ViewVMCreate, ViewVMEdit, ViewVMDelete, ViewVMSelect, ViewCPUOptions, ViewVMRunning, ViewPCIPassthrough, ViewUSBPassthrough, ViewCPUTopology, ViewVCPUPinning, ViewSSHPassword, ViewStartStopScript, ViewLVCreate, ViewMountPointWarning:
 		return true
 	}
 	return false
@@ -799,6 +799,17 @@ func (m *MainModel) delegateToSubView(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// LV create is handled earlier in MainModel.update() so it can receive
 		// asynchronous non-key messages (e.g., lvVGsLoadedMsg) reliably.
 		return m, nil
+	case ViewMountPointWarning:
+		if m.mountPointWarningModel != nil {
+			model, cmd := m.mountPointWarningModel.Update(msg)
+			if mpw, ok := model.(*MountPointWarningModel); ok {
+				m.mountPointWarningModel = mpw
+			}
+			if cmd != nil {
+				nextMsg := cmd()
+				return m.handleSubViewOutput(nextMsg)
+			}
+		}
 	case ViewVMRunning:
 		if m.vmRunningModel != nil {
 			vrm, vrmCmd := m.vmRunningModel.Update(msg)

--- a/internal/tui/models/mount_point_warning.go
+++ b/internal/tui/models/mount_point_warning.go
@@ -85,7 +85,7 @@ func (m *MountPointWarningModel) View() string {
 		Bold(true)
 
 	bodyStyle := lipgloss.NewStyle().
-		Foreground(styles.Colors.Text)
+		Foreground(styles.Colors.Foreground)
 
 	noteStyle := lipgloss.NewStyle().
 		Foreground(styles.Colors.Muted).

--- a/internal/tui/models/mount_point_warning.go
+++ b/internal/tui/models/mount_point_warning.go
@@ -1,0 +1,112 @@
+// Package models provides the BubbleTea models for the DKVM Manager TUI
+package models
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/glemsom/dkvmmanager/internal/tui/styles"
+)
+
+const dkvmDataMountPath = "/media/dkvmdata"
+
+// isMountPoint checks whether the given path is a mount point by comparing
+// the device ID of the path with the device ID of its parent directory.
+func isMountPoint(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	parentDir := filepath.Dir(path)
+	parentInfo, err := os.Stat(parentDir)
+	if err != nil {
+		return false, err
+	}
+	// If device IDs differ, it's a mount point
+	return info.Sys().(*syscall.Stat_t).Dev != parentInfo.Sys().(*syscall.Stat_t).Dev, nil
+}
+
+// MountPointWarningModel displays a warning modal when /media/dkvmdata
+// is not a mount point, informing the user that the DKVM hypervisor
+// auto-mounts filesystems with LABEL=dkvmdata.
+type MountPointWarningModel struct {
+	// Selected option (0 = OK)
+	selectedIndex int
+}
+
+// NewMountPointWarningModel creates a new mount point warning model.
+func NewMountPointWarningModel() *MountPointWarningModel {
+	return &MountPointWarningModel{
+		selectedIndex: 0,
+	}
+}
+
+// Init initializes the model.
+func (m *MountPointWarningModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles incoming messages.
+func (m *MountPointWarningModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		return m.handleKeyPress(msg)
+	}
+
+	return m, nil
+}
+
+// handleKeyPress handles keyboard input.
+func (m *MountPointWarningModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "enter", " ", "esc":
+		// Dismiss the warning and return to the main menu
+		return m, func() tea.Msg {
+			return ViewChangeMsg{View: ViewMainMenu}
+		}
+	}
+
+	return m, nil
+}
+
+// View returns the view for the model.
+func (m *MountPointWarningModel) View() string {
+	warningTitle := lipgloss.NewStyle().
+		Foreground(styles.Colors.Warning).
+		Bold(true).
+		Padding(0, 1).
+		Render("⚠ Mount Point Warning")
+
+	warningStyle := lipgloss.NewStyle().
+		Foreground(styles.Colors.Warning).
+		Bold(true)
+
+	bodyStyle := lipgloss.NewStyle().
+		Foreground(styles.Colors.Text)
+
+	noteStyle := lipgloss.NewStyle().
+		Foreground(styles.Colors.Muted).
+		Italic(true)
+
+	buttonSelected := lipgloss.NewStyle().
+		Foreground(styles.Colors.Background).
+		Background(styles.Colors.Primary).
+		Bold(true).
+		Padding(0, 2).
+		Render("OK")
+
+	var output string
+	output += warningTitle + "\n\n"
+	output += warningStyle.Render("Warning:") + " " + bodyStyle.Render("/media/dkvmdata is not a mount point.") + "\n\n"
+	output += bodyStyle.Render("The DKVM hypervisor will auto-mount filesystems with LABEL=dkvmdata.") + "\n"
+	output += bodyStyle.Render("To resolve this, create a filesystem with the label 'dkvmdata' and restart.") + "\n\n"
+	output += noteStyle.Render("Note: Most VM settings done in the TUI cannot be persisted without this mount.") + "\n\n"
+
+	output += "  " + buttonSelected + "\n\n"
+	output += noteStyle.Render("Press Enter, Space, or ESC to dismiss")
+
+	return styles.ModalStyle().Render(output)
+}

--- a/internal/tui/models/types.go
+++ b/internal/tui/models/types.go
@@ -30,6 +30,7 @@ const (
 	ViewSSHPassword     = "ssh_password"
 	ViewStartStopScript = "start_stop_script"
 	ViewLVCreate        = "lv_create"
+	ViewMountPointWarning = "mount_point_warning"
 )
 
 // Package-level debug mode flag
@@ -139,6 +140,9 @@ type MainModel struct {
 
 	// LVM LV create model
 	lvCreateModel *LVCreateModel
+
+	// Mount point warning model
+	mountPointWarningModel *MountPointWarningModel
 
 	// VM list for selection
 	vmListForSelection []models.VM

--- a/internal/tui/models/view.go
+++ b/internal/tui/models/view.go
@@ -151,6 +151,11 @@ func (m *MainModel) renderActiveContentWithWidth(width int) string {
 			return m.lvCreateModel.View()
 		}
 		return "Loading..."
+	case ViewMountPointWarning:
+		if m.mountPointWarningModel != nil {
+			return m.mountPointWarningModel.View()
+		}
+		return "Loading..."
 	case ViewVMRunning:
 		if m.vmRunningModel != nil {
 			return m.vmRunningModel.View()


### PR DESCRIPTION
## Summary

Add a mount point warning to the TUI that displays when `/media/dkvmdata` is not mounted, helping users detect missing mount points before issues arise.

## Changes

| File | Description |
|------|-------------|
| `internal/tui/models/mount_point_warning.go` | New model for mount point warning UI |
| `internal/tui/models/init.go` | Initialize mount point warning model |
| `internal/tui/models/key_handlers.go` | Add key handler integration |
| `internal/tui/models/types.go` | Add warning-related types |
| `internal/tui/models/view.go` | Render warning in view layer |
| `TODO.md` | Removed (completed tasks) |

## Commits

- `Cleanup todo`
- `feat(tui): warn when /media/dkvmdata is not a mount point`
- `fix(tui): use styles.Colors.Foreground in mount point warning view`

---
**6 files changed**, +161 / -21