### PR TITLE
docs: add CONTEXT.md glossary and ADR 0001 for live metrics and persi…

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,39 @@
+# DKVM Manager
+
+Terminal UI for KVM/QEMU virtual machine management on a single host.
+
+## Language
+
+**Runner**:
+A `VMRunner` instance owns the full lifecycle of one running QEMU process: it starts the process, holds the QMP client, streams log lines, runs start/stop scripts, owns the metrics snapshot, and tears everything down on stop. A fresh runner is created per VM session; the runner is not reused across runs of the same VM.
+_Avoid_: controller, driver. (Manager is the multi-VM registry and is a different thing — see "Manager" below.)
+
+**Manager**:
+A `vm.Manager` owns the multi-VM registry: listing, lookup, creation, and YAML persistence of VM configurations. It does not own running processes; that is the runner's job.
+_Avoid_: runner (different scope — per-process vs. multi-VM), orchestrator.
+
+**QMP client**:
+A typed wrapper around the QEMU Monitor Protocol over a Unix socket. The QMP client is the only path for guest-side introspection and control (status, vCPU state, block devices, balloon). It is owned by exactly one runner for the lifetime of one QEMU process and is never shared between VMs.
+_Avoid_: "monitor", "QMP socket" (the socket is the wire; the client is the wrapper).
+
+**Persisted log**:
+A per-VM file at `<DataFolder>/vms/<id>/qemu.log` written by the runner. It mirrors the runner's internal log channel — QEMU stdout, QEMU stderr, and start/stop script output, all prefixed (e.g. `[stderr] `, `[start] `) and in arrival order — so log history survives view re-entry and VM exit. The persisted log is the source of truth for post-mortem; the in-memory log channel is a live tail.
+_Avoid_: "log file" (too generic), "QEMU log" (confuses the channel with the file), "vm log".
+
+**Log subscription**:
+The runner's `Subscribe() <-chan string` API, which hands out a fresh buffered channel and lets the caller drain it before receiving new lines. Replaces the older `LogChan() <-chan string` global channel. The drain-on-subscribe semantic is what lets the view recover missed lines from the persisted log without duplicating them.
+_Avoid_: "LogChan" (the old name), "log channel" (suggests the old global channel).
+
+**Metrics snapshot**:
+A point-in-time value object returned by `runner.Snapshot()` containing both QMP-derived guest metrics (per-vCPU time, per-block I/O counters, balloon size) and host `/proc/<pid>`-derived metrics for the QEMU process (RSS, CPU time). Snapshots are produced on a 2 s cadence, decoupled from the 500 ms status poll.
+_Avoid_: "live metrics" (that is the *cadence*; the value object is a snapshot), "stats", "telemetry".
+
+**Status poll**:
+The fast (500 ms) QMP-derived read that powers the existing `[RUNNING]` / `[STARTING]` / `[STOPPING]` badge and the vCPU thread-ID list. Distinct from the metrics snapshot: status is cheap, binary-ish, and shared with the view's existing key path; metrics is heavier, numerical, and lives on its own cadence.
+_Avoid_: "metrics poll" (status is not metrics), "health check" (carries external-service connotations we don't have).
+
+## Package boundaries
+
+- `internal/vm` is the *data plane* for running VMs: the runner, the QMP client, the metrics snapshot, the persisted log. Anything that talks to QEMU or the host kernel about a running process lives here.
+- `internal/tui/models` is the *view plane*: BubbleTea models, key handlers, message dispatch, rendering. The view plane imports `internal/vm`; `internal/vm` does not import the view plane.
+- The runner is the only object that crosses the boundary in both directions: it exposes `Snapshot()`, `Subscribe()`, `PID()`, `QMPClient()` for the view, and consumes the QMP client, `/proc`, and the disk for itself.

--- a/docs/adr/0001-runner-owned-running-vm-data-plane.md
+++ b/docs/adr/0001-runner-owned-running-vm-data-plane.md
@@ -1,0 +1,24 @@
+# Runner owns the running-VM data plane
+
+Status: accepted
+
+For the live-metrics and persisted-log features, the runner is the single owner of three things: the metrics snapshot (QMP + `/proc/<pid>`), the on-disk `qemu.log`, and the log subscription API. The view is a pure renderer; the QMP client is owned by one runner for the life of one QEMU process. Status polling and metrics polling run on decoupled cadences (500 ms and 2 s) behind two independent `tea.Tick` commands.
+
+## Considered Options
+
+- **View-driven metrics, client-direct (M.1).** `VMRunningModel` calls `client.QueryCPUs()` / `QueryBlockStats()` / `QueryBalloon()` directly, holds the previous sample in the view, and computes deltas. Rejected because: the view has no mutex of its own, the `/proc` reader's error cases (`pid == 0`, `os.ErrNotExist` on early/late lifecycle) belong with the runner, and the (C.3)-shaped future would have to *move* this state back into the runner — forward-incompatible.
+- **One tick, many queries, serialised (C.1).** Keep the existing 500 ms tick and just add `query-cpus` / `query-blockstats` / `query-balloon` to it. Rejected because: each query takes 50–150 ms on a busy VM; a single tick would let log-stream responsiveness degrade with VM load.
+- **Per-stream persisted log files (b.2).** Split into `qemu-stdout.log`, `qemu-stderr.log`, `start.log`, `stop.log`. Rejected because: the user pain is "I lost the log"; splitting trades that for "which of the four files do I open?". The prefix scheme the runner already uses disambiguates streams inside one file.
+- **Structured JSONL persisted log (b.3).** `qemu.log.jsonl` with `{"ts", "stream", "line"}` records. Deferred — the line model stays the same so we can migrate later, but YAGNI for v1.
+- **JSON-line metric snapshots (T.3).** Define the `Metrics` type twice, once for wire and once for display. Rejected — verbose, no benefit while we have one consumer.
+- **View-owned log persistence.** The TUI writes the file as a side effect of `VMLogMsg`. Rejected because: the file then exists only when the TUI was running, which is exactly the case we want to fix (post-mortem after the TUI has exited).
+
+## Consequences
+
+- **API change**: `runner.LogChan() <-chan string` becomes `runner.Subscribe() <-chan string`. The view must `Subscribe()` (which hands out a fresh buffered channel and drains any pre-existing buffer the runner may have staged) and then iterate. Only the TUI consumes this; the breaking change is small and well-contained.
+- **Forward compatibility with (C.3)**: when we eventually move from view-driven metrics cadence to a runner-driven background poller, only the *implementation* of `Snapshot()` changes. The view's call site is untouched. Choosing (M.2) today is what makes this safe.
+- **Concurrency discipline**: the 6 existing reader goroutines (QEMU stdout, QEMU stderr, start-stdout, start-stderr, stop-stdout, stop-stderr) all send to a single internal `chan string` consumed by a dedicated flusher goroutine that writes the persisted log with a `*bufio.Writer`. A slow disk must never block a QEMU pipe, so the file write is intentionally one level removed from the readers.
+- **Deadlock prevention**: the v0.1.18 fix (VMRunning polling and log messages bypass the view registry dispatch) extends. The new `pollMetrics()` tick must also bypass the registry and feed `VMMetricsUpdateMsg` directly to `VMRunningModel.Update`.
+- **PID accessor**: `VMRunner` gains a `PID() int` accessor (one-liner, under the existing `r.mu`) so the `/proc` reader can locate the QEMU process.
+- **New QMP methods**: `QueryCPUs()` (distinct from the existing `QueryCPUsFast()` — needs CPU time in ns for delta math), `QueryBlockStats()`, `QueryBalloon()`. All typed. All serialised through the existing client mutex.
+- **New value type**: `internal/vm/metrics.go` with the `Metrics` struct. Imported by the view for display; the view is otherwise free of QMP semantics.


### PR DESCRIPTION
…sted log

Captures the vocabulary and architectural decisions for issue #49 (Live VM metrics and persisted QEMU log):

- CONTEXT.md: locks the canonical terms (Runner, Manager, QMP client, Persisted log, Log subscription, Metrics snapshot, Status poll) and records the package-boundary rule (internal/vm is the data plane, internal/tui/models is the view plane).

- docs/adr/0001-runner-owned-running-vm-data-plane.md: records the decision that the runner owns the metrics snapshot, the persisted log, and the log subscription API; status and metrics polling run on decoupled 500 ms / 2 s cadences; the LogChan() API becomes Subscribe() to support drain-on-subscribe for replay-without-dupes.

Rejected alternatives and downstream consequences (Subscribe API change, QMPClientInterface for testability, deadlock-prevention extension, forward compatibility with a (C.3)-shaped future) are listed in the ADR.

## Description

<!-- Briefly describe what this PR changes and why. -->

## Type of change

<!-- Check the box that applies. This helps generate changelog entries. -->

- [ ] `feat` — New feature (will appear in "Added" section)
- [ ] `fix` — Bug fix (will appear in "Fixed" section)
- [ ] `refactor` — Code refactoring (no user-facing change)
- [ ] `docs` — Documentation only
- [ ] `test` — Test additions or fixes
- [ ] `ci` — CI/CD configuration
- [ ] `chore` — Other maintenance

## Conventional Commit title

<!-- Write a Conventional-Commit-style title for this PR. Example:
     feat: add striped LVM support in configuration dialog
     fix: resolve silent failure in OVMF file operations -->

```
<type>[optional scope]: <short description>
```

## Checklist

- [ ] Tests pass locally (`make test`)
- [ ] Code builds without errors (`make build`)
- [ ] CHANGELOG.md updated if this change won't be auto-detected
- [ ] Commit messages follow Conventional Commits format
