### PR TITLE
style: replace rounded borders with straight borders for TERM=linux support (#74)

### DIFF
--- a/internal/tui/components/vm_cards.go
+++ b/internal/tui/components/vm_cards.go
@@ -96,7 +96,7 @@ func (c *VMCardView) renderCard(vm models.VM, selected bool) string {
 		borderColor = styles.Colors.Muted
 	}
 
-	// Use ASCII fallback on TERM=linux (vgacon can't render Unicode box-drawing)
+	// Straight box-drawing (┌┐└┘─│) works on TERM=linux (CP437) and all modern terminals.
 	topLeft, topRight, bottomLeft, bottomRight, horiz, vert := cardBorderChars()
 
 	// Top border with title
@@ -158,13 +158,10 @@ func (c *VMCardView) renderCard(vm models.VM, selected bool) string {
 	return card
 }
 
-// cardBorderChars returns border characters for VM card rendering.
-// Uses ASCII fallback on TERM=linux (vgacon) where Unicode box-drawing may not render.
+// cardBorderChars returns straight border characters for VM card rendering.
+// NormalBorder (┌┐└┘├┤─│) characters are in CP437 and work on all terminals.
 func cardBorderChars() (topLeft, topRight, bottomLeft, bottomRight, horiz, vert string) {
-	if styles.IsTermLinux() {
-		return "+", "+", "+", "+", "-", "|"
-	}
-	return "╭", "╮", "╰", "╯", "─", "│"
+	return "┌", "┐", "└", "┘", "─", "│"
 }
 
 // SelectedVM returns the currently selected VM

--- a/internal/tui/components/vm_details.go
+++ b/internal/tui/components/vm_details.go
@@ -218,7 +218,7 @@ func (p *VMDetailsPanel) renderActionBar(width int) string {
 
 	borderColor := styles.Colors.Muted
 	actionBar := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
+		Border(lipgloss.NormalBorder()).
 		BorderForeground(borderColor).
 		Padding(1, 2).
 		Width(width).

--- a/internal/tui/styles/ascii_fallback.go
+++ b/internal/tui/styles/ascii_fallback.go
@@ -86,26 +86,21 @@ func GetModeIcon(mode string) string {
 	return "◌"
 }
 
-// NormalBorder returns NormalBorder on capable terminals, ASCII fallback on TERM=linux.
+// NormalBorder returns NormalBorder.
+// Straight box-drawing (┌┐└┘├┤─│) works on all terminals including TERM=linux (CP437).
 func NormalBorder() lipgloss.Border {
-	if IsTermLinux() {
-		return lipgloss.ASCIIBorder()
-	}
 	return lipgloss.NormalBorder()
 }
 
-// RoundedBorder returns RoundedBorder on capable terminals, ASCII fallback on TERM=linux.
+// RoundedBorder returns NormalBorder.
+// Previously returned RoundedBorder (╭╮╰╯), but those arcs are not in CP437
+// and don't render on TERM=linux. Straight borders work everywhere.
 func RoundedBorder() lipgloss.Border {
-	if IsTermLinux() {
-		return lipgloss.ASCIIBorder()
-	}
-	return lipgloss.RoundedBorder()
+	return lipgloss.NormalBorder()
 }
 
-// GetBorder returns the given border on capable terminals, ASCII fallback on TERM=linux.
+// GetBorder returns the given border unchanged.
+// Straight box-drawing works on all terminals, no fallback needed.
 func GetBorder(b lipgloss.Border) lipgloss.Border {
-	if IsTermLinux() {
-		return lipgloss.ASCIIBorder()
-	}
 	return b
 }

--- a/internal/tui/styles/ascii_fallback_test.go
+++ b/internal/tui/styles/ascii_fallback_test.go
@@ -105,11 +105,11 @@ func TestBorderStyle_Ascii(t *testing.T) {
 	t.Setenv("TERM", "linux")
 	style := BorderStyle()
 	rendered := style.Render("Test")
-	if !strings.Contains(rendered, "+") {
-		t.Errorf("BorderStyle() with TERM=linux should use ASCII border with '+', got: %q", rendered)
+	if !strings.Contains(rendered, "┌") {
+		t.Errorf("BorderStyle() with TERM=linux should use NormalBorder with '┌', got: %q", rendered)
 	}
 	if strings.Contains(rendered, "╭") || strings.Contains(rendered, "╮") {
-		t.Errorf("BorderStyle() with TERM=linux should NOT use Unicode border chars, got: %q", rendered)
+		t.Errorf("BorderStyle() with TERM=linux should NOT use RoundedBorder chars, got: %q", rendered)
 	}
 }
 
@@ -117,8 +117,8 @@ func TestBorderStyle_Unicode(t *testing.T) {
 	t.Setenv("TERM", "xterm-256color")
 	style := BorderStyle()
 	rendered := style.Render("Test")
-	if !strings.Contains(rendered, "╭") {
-		t.Errorf("BorderStyle() with TERM=xterm-256color should use Unicode border, got: %q", rendered)
+	if !strings.Contains(rendered, "┌") {
+		t.Errorf("BorderStyle() with TERM=xterm-256color should use NormalBorder with '┌', got: %q", rendered)
 	}
 }
 
@@ -126,11 +126,11 @@ func TestActiveBorderStyle_Ascii(t *testing.T) {
 	t.Setenv("TERM", "linux")
 	style := ActiveBorderStyle()
 	rendered := style.Render("Test")
-	if !strings.Contains(rendered, "+") {
-		t.Errorf("ActiveBorderStyle() with TERM=linux should use ASCII border with '+', got: %q", rendered)
+	if !strings.Contains(rendered, "┌") {
+		t.Errorf("ActiveBorderStyle() with TERM=linux should use NormalBorder with '┌', got: %q", rendered)
 	}
 	if strings.Contains(rendered, "╭") || strings.Contains(rendered, "╮") {
-		t.Errorf("ActiveBorderStyle() with TERM=linux should NOT use Unicode border chars, got: %q", rendered)
+		t.Errorf("ActiveBorderStyle() with TERM=linux should NOT use RoundedBorder chars, got: %q", rendered)
 	}
 }
 
@@ -138,8 +138,8 @@ func TestActiveBorderStyle_Unicode(t *testing.T) {
 	t.Setenv("TERM", "xterm-256color")
 	style := ActiveBorderStyle()
 	rendered := style.Render("Test")
-	if !strings.Contains(rendered, "╭") {
-		t.Errorf("ActiveBorderStyle() with TERM=xterm-256color should use Unicode border, got: %q", rendered)
+	if !strings.Contains(rendered, "┌") {
+		t.Errorf("ActiveBorderStyle() with TERM=xterm-256color should use NormalBorder with '┌', got: %q", rendered)
 	}
 }
 
@@ -147,8 +147,8 @@ func TestInputStyle_Ascii(t *testing.T) {
 	t.Setenv("TERM", "linux")
 	style := InputStyle()
 	rendered := style.Render("Test")
-	if !strings.Contains(rendered, "+") {
-		t.Errorf("InputStyle() with TERM=linux should use ASCII border with '+', got: %q", rendered)
+	if !strings.Contains(rendered, "┌") {
+		t.Errorf("InputStyle() with TERM=linux should use NormalBorder with '┌', got: %q", rendered)
 	}
 }
 
@@ -165,8 +165,8 @@ func TestTooltipStyle_Ascii(t *testing.T) {
 	t.Setenv("TERM", "linux")
 	style := TooltipStyle()
 	rendered := style.Render("Test")
-	if !strings.Contains(rendered, "+") {
-		t.Errorf("TooltipStyle() with TERM=linux should use ASCII border with '+', got: %q", rendered)
+	if !strings.Contains(rendered, "┌") {
+		t.Errorf("TooltipStyle() with TERM=linux should use NormalBorder with '┌', got: %q", rendered)
 	}
 }
 
@@ -174,8 +174,8 @@ func TestTooltipStyle_Unicode(t *testing.T) {
 	t.Setenv("TERM", "xterm-256color")
 	style := TooltipStyle()
 	rendered := style.Render("Test")
-	if !strings.Contains(rendered, "╭") {
-		t.Errorf("TooltipStyle() with TERM=xterm-256color should use RoundedBorder, got: %q", rendered)
+	if !strings.Contains(rendered, "┌") {
+		t.Errorf("TooltipStyle() with TERM=xterm-256color should use NormalBorder with '┌', got: %q", rendered)
 	}
 }
 
@@ -183,7 +183,7 @@ func TestModalStyle_Ascii(t *testing.T) {
 	t.Setenv("TERM", "linux")
 	style := ModalStyle()
 	rendered := style.Render("Test")
-	if !strings.Contains(rendered, "+") {
-		t.Errorf("ModalStyle() with TERM=linux should use ASCII border with '+', got: %q", rendered)
+	if !strings.Contains(rendered, "┌") {
+		t.Errorf("ModalStyle() with TERM=linux should use NormalBorder with '┌', got: %q", rendered)
 	}
 }

--- a/internal/tui/styles/colors.go
+++ b/internal/tui/styles/colors.go
@@ -234,14 +234,14 @@ func FooterStyle() lipgloss.Style {
 // BorderStyle returns the style for borders
 func BorderStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Border(RoundedBorder()).
+		Border(NormalBorder()).
 		BorderForeground(Colors.Border)
 }
 
 // ActiveBorderStyle returns the style for active/focused borders
 func ActiveBorderStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Border(RoundedBorder()).
+		Border(NormalBorder()).
 		BorderForeground(Colors.Primary)
 }
 

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -145,7 +145,7 @@ func TooltipStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
 		Foreground(Colors.Foreground).
 		Background(Colors.Background).
-		Border(RoundedBorder()).
+		Border(NormalBorder()).
 		BorderForeground(Colors.Border).
 		Padding(1, 2)
 }
@@ -153,7 +153,7 @@ func TooltipStyle() lipgloss.Style {
 // ModalStyle returns the style for modal dialogs
 func ModalStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Border(RoundedBorder()).
+		Border(NormalBorder()).
 		BorderForeground(Colors.Primary).
 		Background(Colors.Background).
 		Padding(1, 2)
@@ -162,7 +162,7 @@ func ModalStyle() lipgloss.Style {
 // NotificationStyle returns the style for notifications
 func NotificationStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Border(RoundedBorder()).
+		Border(NormalBorder()).
 		BorderForeground(Colors.Primary).
 		Background(Colors.Background).
 		Padding(1, 2)
@@ -171,7 +171,7 @@ func NotificationStyle() lipgloss.Style {
 // ErrorNotificationStyle returns the style for error notifications
 func ErrorNotificationStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Border(RoundedBorder()).
+		Border(NormalBorder()).
 		BorderForeground(Colors.Error).
 		Background(Colors.Background).
 		Padding(1, 2)
@@ -180,7 +180,7 @@ func ErrorNotificationStyle() lipgloss.Style {
 // SuccessNotificationStyle returns the style for success notifications
 func SuccessNotificationStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Border(RoundedBorder()).
+		Border(NormalBorder()).
 		BorderForeground(Colors.Success).
 		Background(Colors.Background).
 		Padding(1, 2)
@@ -189,7 +189,7 @@ func SuccessNotificationStyle() lipgloss.Style {
 // WarningNotificationStyle returns the style for warning notifications
 func WarningNotificationStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Border(RoundedBorder()).
+		Border(NormalBorder()).
 		BorderForeground(Colors.Warning).
 		Background(Colors.Background).
 		Padding(1, 2)


### PR DESCRIPTION
## Problem

`RoundedBorder()` (╭╮╰╯) does not render on DKVM host tty1 (TERM=linux). Kernel VGA font only has CP437 — rounded arcs fall back to `+`.

## Solution

Replace all `RoundedBorder()` usages with `NormalBorder()` (straight box-drawing). These chars (┌┐└┘├┤─│) are in CP437 and render correctly everywhere.

### Changes

- **`ascii_fallback.go`** — `NormalBorder()` always returns `lipgloss.NormalBorder()`; `RoundedBorder()` aliases it; `GetBorder()` is passthrough
- **`styles.go`** — 6 styles: Tooltip, Modal, Notification + 3 variants: `RoundedBorder()` → `NormalBorder()`
- **`colors.go`** — `BorderStyle()` + `ActiveBorderStyle()`: same swap
- **`vm_cards.go`** — card corners: ╭╮╰╯ → ┌┐└┘; removed TERM-dependent ASCII fallback
- **`vm_details.go`** — action bar: `lipgloss.RoundedBorder()` → `lipgloss.NormalBorder()`
- **`ascii_fallback_test.go`** — tests updated to expect NormalBorder (┌) instead of ASCII (+) or Rounded (╭)

## Verification

`make test` — all 12 suites pass.

Closes #74