### PR TITLE
fix: remove redundant persistBuf.Flush() in dry-run path to fix data race

### DIFF
--- a/internal/vm/vm_runner.go
+++ b/internal/vm/vm_runner.go
@@ -878,11 +878,9 @@ func (r *VMRunner) Start() error {
 		r.logChan <- "[DRY-RUN] Filtered QEMU command (no passthrough):"
 		r.logChan <- filteredCmd
 
-		// Flush the persisted log so the file is available to the caller
-		// but keep the channels open for the view to consume.
-		if r.persistBuf != nil {
-			_ = r.persistBuf.Flush()
-		}
+		// No explicit flush needed: writePersistLine (called by persistLogLoop)
+		// flushes every line. The subscriber channel ordering guarantees the
+		// file is up-to-date once the caller receives all lines.
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Fixes #76 — data race in `TestPersistLogDryRunWritesToFile`.

## Root Cause

`Start()`'s dry-run path called `r.persistBuf.Flush()` directly from the calling goroutine while the `persistLogLoop` goroutine could concurrently access the same `*bufio.Writer` via `writePersistLine()`.

## Fix

`writePersistLine()` already flushes `r.persistBuf` after every line (line 287). The explicit `Flush()` in the dry-run path was therefore redundant — it deferred nothing that wasn't already flushed by the goroutine.

Removing it eliminates the racy access entirely. The subscriber channel ordering (write → flush → notify) guarantees the file is up-to-date once the caller receives all lines.

## Verification

`go test -race -count=5 -run TestPersistLogDryRunWritesToFile ./internal/vm/` — passes with no race. All persist-log tests pass with `-race -count=3`.