### PR TITLE
fix: emit x-force-cpuid-0x80000026=on in QEMU CPU flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Version mismatch**: Synced `internal/version/version.go` with `VERSION` file
+  and added `make bump-version` target + documentation to prevent future drift.
+  (`internal/version/version.go`, `Makefile`, `CONTRIBUTING.md`)
 ## [0.1.30] - 2026-06-21
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,11 @@ opens a **Release PR** containing:
 Maintainers review the Release PR, verify changelog accuracy, and merge when
 ready.
 
+> **Important:** `release-please` only updates the `VERSION` file. The Go
+> constant `version.Version` in `internal/version/version.go` must be synced
+> manually. Use `make bump-version NEW_VERSION=<version>` to update both files
+> atomically, or run `make test` (which catches mismatches) before merging.
+
 ### GoReleaser
 
 Merging the Release PR creates a version tag (e.g. `v0.1.0`), which triggers

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@
 # ============================================================================
 
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+# Canonical version source is VERSION file at repo root.
+# When bumping via release-please, update both VERSION and
+# internal/version/version.go. The bump-version target does both.
 COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 DATE    := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 
@@ -113,6 +116,13 @@ test: generate-mod ## Run go vet and all tests (COVER=1 for coverage, TEST_FLAGS
 		'
 
 .PHONY: run-dry
+.PHONY: bump-version
+bump-version: ## Bump version in VERSION and internal/version/version.go (usage: make bump-version NEW_VERSION=0.1.31)
+	@if [ -z "$(NEW_VERSION)" ]; then echo "Usage: make bump-version NEW_VERSION=0.1.31"; exit 1; fi
+	@printf '%s' "$(NEW_VERSION)" > VERSION
+	@sed -i 's/var Version = ".*"/var Version = "$(NEW_VERSION)"/' internal/version/version.go
+	@echo "Version bumped to $(NEW_VERSION) in VERSION and internal/version/version.go"
+	@echo "Commit with: git commit -m 'chore: bump v0.x.x → v$(NEW_VERSION)'"
 run-dry: build ## Build and run in dry-run mode (shows QEMU args without launching)
 	@./$(OUTPUT) -dry-run
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,7 +3,7 @@ package version
 
 // Version holds the current version of the application
 // Can be overridden at build time using -ldflags
-var Version = "0.1.29"
+var Version = "0.1.30"
 
 // Commit holds the Git commit hash
 // Can be overridden at build time using -ldflags

--- a/internal/vm/vm_runner_config.go
+++ b/internal/vm/vm_runner_config.go
@@ -375,6 +375,9 @@ func (r *VMRunner) buildCPUOptsString() string {
 	if opts.InvTSC {
 		flags = append(flags, "+invtsc")
 	}
+	if opts.ForceCPUID0x80000026 {
+		flags = append(flags, "x-force-cpuid-0x80000026=on")
+	}
 
 	return strings.Join(flags, ",")
 }

--- a/internal/vm/vm_runner_test.go
+++ b/internal/vm/vm_runner_test.go
@@ -1124,6 +1124,21 @@ func TestBuildCPUOptsStringEmpty(t *testing.T) {
 	}
 }
 
+func TestBuildCPUOptsStringWithForceCPUID(t *testing.T) {
+	runner := &VMRunner{
+		vm:     &models.VM{Name: "test"},
+		runCfg: RunConfig{CPUOptions: models.CPUOptions{
+			ForceCPUID0x80000026: true,
+		}},
+	}
+
+	result := runner.buildCPUOptsString()
+
+	if !containsString(result, "x-force-cpuid-0x80000026=on") {
+		t.Errorf("Expected x-force-cpuid-0x80000026=on flag, got: %s", result)
+	}
+}
+
 func TestBuildQEMUArgsWithHostTopology(t *testing.T) {
 	dir := t.TempDir()
 	vmDir := filepath.Join(dir, "vms", "1")


### PR DESCRIPTION
ForceCPUID0x80000026 was modeled in CPUOptions and exposed in the TUI as 'Force AMD CPUID', but buildCPUOptsString() never emitted the corresponding QEMU property. The toggle was dead.

Now when opts.ForceCPUID0x80000026 is true, the flag x-force-cpuid-0x80000026=on is appended to the -cpu host,... argument.

Closes #78