### PR TITLE
feat: per-die L3 cache size override (l3-cache-size-die<N>)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Per-die L3 cache size override**: New `L3CacheSizeDie` CPU option to set
+  `l3-cache-size-die<N>=<size>` QEMU flags for asymmetric AMD V-cache CPUs
+  (9950X3D, EPYC). The CPU options form now shows per-die L3 cache size
+  text fields with detected sizes from the host topology scanner.
+  ([#79](https://github.com/glemsom/dkvmmanager/issues/79))
+  (`internal/models/models.go`, `internal/vm/vm_runner_config.go`,
+  `internal/tui/models/cpu_options_form.go`,
+  `internal/tui/models/cpu_options_form_navigation.go`,
+  `internal/tui/models/cpu_options_form_render.go`)
+
 ### Fixed
 - **Version mismatch**: Synced `internal/version/version.go` with `VERSION` file
   and added `make bump-version` target + documentation to prevent future drift.

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -140,7 +140,8 @@ type CPUOptions struct {
 	HVIPI                  bool   `json:"hv_ipi" yaml:"hv_ipi"`
 	HVAVIC                 bool   `json:"hv_avic" yaml:"hv_avic"`
 	TopoExt                bool   `json:"topoext" yaml:"topoext"`
-	L3Cache                bool   `json:"l3_cache" yaml:"l3_cache"`
+	L3Cache                bool              `json:"l3_cache" yaml:"l3_cache"`
+	L3CacheSizeDie        map[int]string    `json:"l3_cache_size_die" yaml:"l3_cache_size_die"`
 	X2APIC                 bool   `json:"x2apic" yaml:"x2apic"`
 	Migratable             bool   `json:"migratable" yaml:"migratable"`
 	InvTSC                 bool   `json:"invtsc" yaml:"invtsc"`

--- a/internal/tui/models/cpu_options_form.go
+++ b/internal/tui/models/cpu_options_form.go
@@ -3,6 +3,7 @@ package models
 
 import (
 	"reflect"
+	"strconv"
 	"strings"
 
 	"charm.land/bubbles/v2/viewport"
@@ -18,6 +19,10 @@ import (
 type CPUOptionsFormModel struct {
 	repo    *vm.Repository
 	options *models.CPUOptions
+
+	// Host topology data (for per-die L3 cache override)
+	hostTopo models.HostCPUTopology
+	scanErr  error
 
 	// Focus state
 	positions  []form.FocusPos
@@ -49,9 +54,16 @@ type CPUOptionsFormModel struct {
 func NewCPUOptionsFormModel(repo *vm.Repository) *CPUOptionsFormModel {
 	var opts models.CPUOptions
 	repo.GetConfig("cpu_options", &opts)
+
+	// Scan host topology for per-die L3 cache info
+	scanner := vm.NewCPUScanner()
+	hostTopo, scanErr := scanner.ScanTopology()
+
 	m := &CPUOptionsFormModel{
 		repo:          repo,
 		options:       &opts,
+		hostTopo:      hostTopo,
+		scanErr:       scanErr,
 		cursorOffsets: make(map[string]int),
 		errors:        make(map[string]string),
 	}
@@ -249,13 +261,48 @@ func (m *CPUOptionsFormModel) toggleValue(fieldName string) {
 }
 
 // getTextValue returns the text value for a field (uses reflection).
+// Special-cases L3CacheSizeDie<N> to read from the L3CacheSizeDie map.
 func (m *CPUOptionsFormModel) getTextValue(fieldName string) string {
+	if dieIdx := parseL3CacheSizeDieField(fieldName); dieIdx >= 0 {
+		if m.options.L3CacheSizeDie == nil {
+			return ""
+		}
+		return m.options.L3CacheSizeDie[dieIdx]
+	}
 	return m.getStringField(fieldName)
 }
 
 // setTextValue sets the text value for a field (uses reflection).
+// Special-cases L3CacheSizeDie<N> to write to the L3CacheSizeDie map.
 func (m *CPUOptionsFormModel) setTextValue(fieldName string, val string) {
+	if dieIdx := parseL3CacheSizeDieField(fieldName); dieIdx >= 0 {
+		if m.options.L3CacheSizeDie == nil {
+			m.options.L3CacheSizeDie = make(map[int]string)
+		}
+		if val == "" {
+			delete(m.options.L3CacheSizeDie, dieIdx)
+		} else {
+			m.options.L3CacheSizeDie[dieIdx] = val
+		}
+		return
+	}
 	m.setStringField(fieldName, val)
+}
+
+// parseL3CacheSizeDieField extracts die index from "L3CacheSizeDie<N>" or returns -1.
+func parseL3CacheSizeDieField(name string) int {
+	if !strings.HasPrefix(name, "L3CacheSizeDie") {
+		return -1
+	}
+	suffix := strings.TrimPrefix(name, "L3CacheSizeDie")
+	if suffix == "" {
+		return -1
+	}
+	idx, err := strconv.Atoi(suffix)
+	if err != nil {
+		return -1
+	}
+	return idx
 }
 
 // getFieldKind returns the field kind for a given field name from the registry.

--- a/internal/tui/models/cpu_options_form.go
+++ b/internal/tui/models/cpu_options_form.go
@@ -73,6 +73,25 @@ func NewCPUOptionsFormModel(repo *vm.Repository) *CPUOptionsFormModel {
 	return m
 }
 
+// NewCPUOptionsFormModelWithTopo creates a form with explicit host topology (for testing).
+// Skips the host CPU scan and uses the provided topology data instead.
+func NewCPUOptionsFormModelWithTopo(repo *vm.Repository, hostTopo models.HostCPUTopology, scanErr error) *CPUOptionsFormModel {
+	var opts models.CPUOptions
+	repo.GetConfig("cpu_options", &opts)
+
+	m := &CPUOptionsFormModel{
+		repo:          repo,
+		options:       &opts,
+		hostTopo:      hostTopo,
+		scanErr:       scanErr,
+		cursorOffsets: make(map[string]int),
+		errors:        make(map[string]string),
+	}
+	m.positions = m.BuildPositions()
+	m.focusIndex = 1
+	return m
+}
+
 // getBoolField returns a boolean field value by name using reflection.
 func (m *CPUOptionsFormModel) getBoolField(name string) bool {
 	v := reflect.ValueOf(m.options).Elem().FieldByName(name)

--- a/internal/tui/models/cpu_options_form_navigation.go
+++ b/internal/tui/models/cpu_options_form_navigation.go
@@ -2,6 +2,8 @@
 package models
 
 import (
+	"fmt"
+
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 )
 
@@ -111,6 +113,24 @@ func (m *CPUOptionsFormModel) BuildPositions() []form.FocusPos {
 		Kind: form.FocusToggle, Label: "Expose host L3 cache info", Key: "L3Cache",
 		Data: cpuOptFocusData{kind: int(form.FocusToggle), fieldName: "L3Cache"},
 	})
+
+	// Per-die L3 cache size override fields
+	if m.scanErr == nil && len(m.hostTopo.Dies) > 0 {
+		positions = append(positions, form.FocusPos{
+			Kind: form.FocusHeader, Label: "== Per-Die L3 Cache Override ==", Key: "header_l3_die",
+		})
+		for _, die := range m.hostTopo.Dies {
+			label := fmt.Sprintf("Die %d L3 cache size (e.g. 32M, 96M)", die.ID)
+			if die.L3CacheKB > 0 {
+				label += fmt.Sprintf(" — detected: %s", formatCacheSize(die.L3CacheKB))
+			}
+			fieldKey := fmt.Sprintf("L3CacheSizeDie%d", die.ID)
+			positions = append(positions, form.FocusPos{
+				Kind: form.FocusText, Label: label, Key: fieldKey,
+				Data: cpuOptFocusData{kind: int(form.FocusText), fieldName: fieldKey},
+			})
+		}
+	}
 	positions = append(positions, form.FocusPos{
 		Kind: form.FocusToggle, Label: "x2APIC mode (>255 vCPUs)", Key: "X2APIC",
 		Data: cpuOptFocusData{kind: int(form.FocusToggle), fieldName: "X2APIC"},

--- a/internal/tui/models/cpu_options_form_render.go
+++ b/internal/tui/models/cpu_options_form_render.go
@@ -2,6 +2,7 @@
 package models
 
 import (
+	"fmt"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -227,6 +228,10 @@ func (m *CPUOptionsFormModel) fieldLabel(name string) string {
 	}
 	if lbl, ok := labels[name]; ok {
 		return lbl
+	}
+	// Handle dynamic L3CacheSizeDie<N> fields
+	if dieIdx := parseL3CacheSizeDieField(name); dieIdx >= 0 {
+		return fmt.Sprintf("Die %d L3 cache override", dieIdx)
 	}
 	return name
 }

--- a/internal/tui/models/cpu_options_form_render.go
+++ b/internal/tui/models/cpu_options_form_render.go
@@ -16,6 +16,7 @@ var (
 	cpuOptFocusStyle   = styles.FormFocusStyle()
 	cpuOptInputStyle   = styles.FormInputStyle()
 	cpuOptErrorStyle   = styles.ErrorTextStyle()
+	cpuOptWarnStyle    = styles.WarningTextStyle()
 	cpuOptMutedStyle   = styles.FormMutedStyle()
 	cpuOptSaveStyle    = styles.FormSaveStyle()
 	cpuOptSectionStyle = styles.DetailSectionStyle()
@@ -31,6 +32,10 @@ func (m *CPUOptionsFormModel) RenderHeader() string {
 // RenderFooter returns the form footer.
 func (m *CPUOptionsFormModel) RenderFooter() string {
 	var parts []string
+	if m.scanErr != nil {
+		parts = append(parts, "")
+		parts = append(parts, cpuOptWarnStyle.Render(fmt.Sprintf("Warning: CPU topology scan failed: %s", m.scanErr)))
+	}
 	if m.statusMessage != "" {
 		parts = append(parts, "")
 		parts = append(parts, cpuOptErrorStyle.Render(m.statusMessage))
@@ -83,6 +88,12 @@ func (m *CPUOptionsFormModel) renderAllLines() []string {
 	// Header
 	lines = append(lines, cpuOptFocusStyle.Render("CPU Options"))
 	lines = append(lines, "")
+
+	if m.scanErr != nil {
+		lines = append(lines, cpuOptWarnStyle.Render(fmt.Sprintf("Warning: CPU topology scan failed: %s", m.scanErr)))
+		lines = append(lines, cpuOptWarnStyle.Render("Per-die L3 cache override unavailable."))
+		lines = append(lines, "")
+	}
 
 	// Render all positions (including section headers)
 	for i, pos := range m.positions {

--- a/internal/tui/models/cpu_options_form_test.go
+++ b/internal/tui/models/cpu_options_form_test.go
@@ -322,20 +322,12 @@ func TestCPUOptionsFormWithL3CacheSizeDie(t *testing.T) {
 	// The form scans topology at runtime, so we mock it by creating a form and
 	// directly providing hostTopo.
 
-	f := &CPUOptionsFormModel{
-		repo:          repo,
-		options:       &models.CPUOptions{},
-		hostTopo: models.HostCPUTopology{
-			Dies: []models.CPUDie{
-				{ID: 0, L3CacheKB: 32768},
-				{ID: 1, L3CacheKB: 98304},
-			},
+	f := NewCPUOptionsFormModelWithTopo(repo, models.HostCPUTopology{
+		Dies: []models.CPUDie{
+			{ID: 0, L3CacheKB: 32768},
+			{ID: 1, L3CacheKB: 98304},
 		},
-		scanErr:       nil,
-		cursorOffsets: make(map[string]int),
-		errors:        make(map[string]string),
-	}
-	f.positions = f.BuildPositions()
+	}, nil)
 
 	// Find die L3 cache fields
 	var die0Idx, die1Idx int = -1, -1

--- a/internal/tui/models/cpu_options_form_test.go
+++ b/internal/tui/models/cpu_options_form_test.go
@@ -3,12 +3,14 @@ package models
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/glemsom/dkvmmanager/internal/config"
 	"github.com/glemsom/dkvmmanager/internal/models"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/fields"
+	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/vm"
 )
 
@@ -308,6 +310,89 @@ func TestCPUOptionsPositionsCount(t *testing.T) {
 	expectedCount := 29
 	if len(form.positions) != expectedCount {
 		t.Errorf("Expected %d positions, got %d", expectedCount, len(form.positions))
+	}
+}
+
+// TestCPUOptionsFormWithL3CacheSizeDie tests per-die L3 cache size fields in form
+func TestCPUOptionsFormWithL3CacheSizeDie(t *testing.T) {
+	vmManager := createTestVMManager(t)
+	repo := vmManager.Repository()
+
+	// Save host topology with 2 dies so the form shows per-die L3 fields
+	// The form scans topology at runtime, so we mock it by creating a form and
+	// directly providing hostTopo.
+
+	f := &CPUOptionsFormModel{
+		repo:          repo,
+		options:       &models.CPUOptions{},
+		hostTopo: models.HostCPUTopology{
+			Dies: []models.CPUDie{
+				{ID: 0, L3CacheKB: 32768},
+				{ID: 1, L3CacheKB: 98304},
+			},
+		},
+		scanErr:       nil,
+		cursorOffsets: make(map[string]int),
+		errors:        make(map[string]string),
+	}
+	f.positions = f.BuildPositions()
+
+	// Find die L3 cache fields
+	var die0Idx, die1Idx int = -1, -1
+	for i, p := range f.positions {
+		if p.Key == "L3CacheSizeDie0" {
+			die0Idx = i
+		}
+		if p.Key == "L3CacheSizeDie1" {
+			die1Idx = i
+		}
+	}
+
+	if die0Idx < 0 {
+		t.Error("Expected L3CacheSizeDie0 field in positions")
+	}
+	if die1Idx < 0 {
+		t.Error("Expected L3CacheSizeDie1 field in positions")
+	}
+
+	if die0Idx >= 0 {
+		// Check it's a text field
+		if f.positions[die0Idx].Kind != form.FocusText {
+			t.Errorf("L3CacheSizeDie0 kind = %d, want FocusText", f.positions[die0Idx].Kind)
+		}
+		// Check label mentions detected size
+		label := f.positions[die0Idx].Label
+		if !strings.Contains(label, "Die 0") || !strings.Contains(label, "32M") {
+			t.Errorf("L3CacheSizeDie0 label = %q, should mention Die 0 and 32M", label)
+		}
+	}
+
+	// Test editing die 0 L3 cache size (one char at a time)
+	f.focusIndex = die0Idx
+	f.handleCharInput("3")
+	f.handleCharInput("2")
+	f.handleCharInput("M")
+	if f.getTextValue("L3CacheSizeDie0") != "32M" {
+		t.Errorf("After typing '32M', L3CacheSizeDie0 = %q, want 32M", f.getTextValue("L3CacheSizeDie0"))
+	}
+
+	// Verify it's stored in the map
+	if f.options.L3CacheSizeDie[0] != "32M" {
+		t.Errorf("L3CacheSizeDie[0] = %q, want 32M", f.options.L3CacheSizeDie[0])
+	}
+
+	// Test empty clears from map
+	f.focusIndex = die0Idx
+	// Clear the field
+	for i := 0; i < 3; i++ {
+		f.handleBackspaceKey()
+	}
+	if f.getTextValue("L3CacheSizeDie0") != "" {
+		t.Errorf("After clearing, L3CacheSizeDie0 = %q, want empty", f.getTextValue("L3CacheSizeDie0"))
+	}
+	// Entry should be deleted from map, not just empty string
+	if _, exists := f.options.L3CacheSizeDie[0]; exists {
+		t.Errorf("L3CacheSizeDie[0] should be deleted after clearing")
 	}
 }
 

--- a/internal/vm/cpu_options_persistence_test.go
+++ b/internal/vm/cpu_options_persistence_test.go
@@ -90,6 +90,11 @@ func TestSaveAndLoadCPUOptions(t *testing.T) {
 	if loaded.HVFrequency {
 		t.Errorf("HVFrequency = %v, want false", loaded.HVFrequency)
 	}
+
+	// L3CacheSizeDie defaults to nil/empty
+	if len(loaded.L3CacheSizeDie) != 0 {
+		t.Errorf("L3CacheSizeDie default len = %d, want 0", len(loaded.L3CacheSizeDie))
+	}
 }
 
 func TestCPUOptionsRoundTrip(t *testing.T) {

--- a/internal/vm/vm_runner_config.go
+++ b/internal/vm/vm_runner_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/glemsom/dkvmmanager/internal/models"
@@ -366,8 +367,13 @@ func (r *VMRunner) buildCPUOptsString() string {
 	if opts.L3Cache {
 		flags = append(flags, "+l3-cache")
 	}
-	for dieIdx, size := range opts.L3CacheSizeDie {
-		if size != "" {
+	dieIndices := make([]int, 0, len(opts.L3CacheSizeDie))
+	for dieIdx := range opts.L3CacheSizeDie {
+		dieIndices = append(dieIndices, dieIdx)
+	}
+	sort.Ints(dieIndices)
+	for _, dieIdx := range dieIndices {
+		if size := opts.L3CacheSizeDie[dieIdx]; size != "" {
 			flags = append(flags, fmt.Sprintf("l3-cache-size-die%d=%s", dieIdx, size))
 		}
 	}

--- a/internal/vm/vm_runner_config.go
+++ b/internal/vm/vm_runner_config.go
@@ -366,6 +366,11 @@ func (r *VMRunner) buildCPUOptsString() string {
 	if opts.L3Cache {
 		flags = append(flags, "+l3-cache")
 	}
+	for dieIdx, size := range opts.L3CacheSizeDie {
+		if size != "" {
+			flags = append(flags, fmt.Sprintf("l3-cache-size-die%d=%s", dieIdx, size))
+		}
+	}
 	if opts.X2APIC {
 		flags = append(flags, "+x2apic")
 	}

--- a/internal/vm/vm_runner_test.go
+++ b/internal/vm/vm_runner_test.go
@@ -1139,6 +1139,42 @@ func TestBuildCPUOptsStringWithForceCPUID(t *testing.T) {
 	}
 }
 
+func TestBuildCPUOptsStringWithL3CacheSizeDie(t *testing.T) {
+	runner := &VMRunner{
+		vm:     &models.VM{Name: "test"},
+		runCfg: RunConfig{CPUOptions: models.CPUOptions{
+			L3CacheSizeDie: map[int]string{
+				0: "32M",
+				1: "96M",
+			},
+		}},
+	}
+
+	result := runner.buildCPUOptsString()
+
+	if !containsString(result, "l3-cache-size-die0=32M") {
+		t.Errorf("Expected l3-cache-size-die0=32M flag, got: %s", result)
+	}
+	if !containsString(result, "l3-cache-size-die1=96M") {
+		t.Errorf("Expected l3-cache-size-die1=96M flag, got: %s", result)
+	}
+}
+
+func TestBuildCPUOptsStringWithL3CacheSizeDieEmpty(t *testing.T) {
+	runner := &VMRunner{
+		vm:     &models.VM{Name: "test"},
+		runCfg: RunConfig{CPUOptions: models.CPUOptions{
+			L3CacheSizeDie: map[int]string{},
+		}},
+	}
+
+	result := runner.buildCPUOptsString()
+
+	if containsString(result, "l3-cache-size-die") {
+		t.Errorf("Expected no l3-cache-size-die flags for empty map, got: %s", result)
+	}
+}
+
 func TestBuildQEMUArgsWithHostTopology(t *testing.T) {
 	dir := t.TempDir()
 	vmDir := filepath.Join(dir, "vms", "1")


### PR DESCRIPTION
## Summary

Implements per-die L3 cache size override for asymmetric AMD V-cache CPUs (9950X3D, EPYC). Adds `l3-cache-size-die<N>=<size>` QEMU flags to the `-cpu host,<flags>` argument.

Closes #79

## Changes

### Model (`internal/models/models.go`)
- Added `L3CacheSizeDie map[int]string` field to `CPUOptions` for per-die L3 cache size overrides (keys 0..7, values like "32M", "96M")

### QEMU arg emission (`internal/vm/vm_runner_config.go`)
- `buildCPUOptsString()` iterates `L3CacheSizeDie` map and emits `l3-cache-size-die<N>=<size>` flags

### TUI (`internal/tui/models/cpu_options_form*.go`)
- CPU options form now scans host topology and shows per-die text fields for L3 cache override
- Each field shows the detected L3 cache size from the CPU scanner as a hint
- Edited values persist to `L3CacheSizeDie` map; clearing a field removes the entry

### Tests
- Model: Save/load round-trip test for `L3CacheSizeDie` default (nil/empty)
- QEMU: `TestBuildCPUOptsStringWithL3CacheSizeDie` and empty-map test
- TUI: `TestCPUOptionsFormWithL3CacheSizeDie` verifies positions, editing, clearing

## Verification
- [x] All tests pass (`go test ./...`)
- [x] `go vet` clean
- [x] `go build` succeeds