### PR TITLE
feat: add per-die L3 cache associativity override (l3-cache-assoc-die<N>)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `internal/tui/models/cpu_options_form.go`,
   `internal/tui/models/cpu_options_form_navigation.go`,
   `internal/tui/models/cpu_options_form_render.go`)
+- **Per-die L3 cache associativity override**: New `L3CacheAssocDie` CPU option
+  to set `l3-cache-assoc-die<N>=<value>` QEMU flags for asymmetric AMD V-cache
+  CPUs (9950X3D, EPYC). The CPU options form now shows per-die L3 cache
+  associativity text fields alongside the size fields.
+  ([#80](https://github.com/glemsom/dkvmmanager/issues/80))
 
 ### Fixed
 - **Version mismatch**: Synced `internal/version/version.go` with `VERSION` file

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -142,6 +142,7 @@ type CPUOptions struct {
 	TopoExt                bool   `json:"topoext" yaml:"topoext"`
 	L3Cache                bool              `json:"l3_cache" yaml:"l3_cache"`
 	L3CacheSizeDie        map[int]string    `json:"l3_cache_size_die" yaml:"l3_cache_size_die"`
+	L3CacheAssocDie       map[int]int       `json:"l3_cache_assoc_die" yaml:"l3_cache_assoc_die"`
 	X2APIC                 bool   `json:"x2apic" yaml:"x2apic"`
 	Migratable             bool   `json:"migratable" yaml:"migratable"`
 	InvTSC                 bool   `json:"invtsc" yaml:"invtsc"`

--- a/internal/tui/models/cpu_options_form.go
+++ b/internal/tui/models/cpu_options_form.go
@@ -281,6 +281,7 @@ func (m *CPUOptionsFormModel) toggleValue(fieldName string) {
 
 // getTextValue returns the text value for a field (uses reflection).
 // Special-cases L3CacheSizeDie<N> to read from the L3CacheSizeDie map.
+// Special-cases L3CacheAssocDie<N> to read from the L3CacheAssocDie map.
 func (m *CPUOptionsFormModel) getTextValue(fieldName string) string {
 	if dieIdx := parseL3CacheSizeDieField(fieldName); dieIdx >= 0 {
 		if m.options.L3CacheSizeDie == nil {
@@ -288,11 +289,22 @@ func (m *CPUOptionsFormModel) getTextValue(fieldName string) string {
 		}
 		return m.options.L3CacheSizeDie[dieIdx]
 	}
+	if dieIdx := parseL3CacheAssocDieField(fieldName); dieIdx >= 0 {
+		if m.options.L3CacheAssocDie == nil {
+			return ""
+		}
+		val := m.options.L3CacheAssocDie[dieIdx]
+		if val == 0 {
+			return ""
+		}
+		return strconv.Itoa(val)
+	}
 	return m.getStringField(fieldName)
 }
 
 // setTextValue sets the text value for a field (uses reflection).
 // Special-cases L3CacheSizeDie<N> to write to the L3CacheSizeDie map.
+// Special-cases L3CacheAssocDie<N> to write to the L3CacheAssocDie map.
 func (m *CPUOptionsFormModel) setTextValue(fieldName string, val string) {
 	if dieIdx := parseL3CacheSizeDieField(fieldName); dieIdx >= 0 {
 		if m.options.L3CacheSizeDie == nil {
@@ -305,6 +317,20 @@ func (m *CPUOptionsFormModel) setTextValue(fieldName string, val string) {
 		}
 		return
 	}
+	if dieIdx := parseL3CacheAssocDieField(fieldName); dieIdx >= 0 {
+		if m.options.L3CacheAssocDie == nil {
+			m.options.L3CacheAssocDie = make(map[int]int)
+		}
+		if val == "" {
+			delete(m.options.L3CacheAssocDie, dieIdx)
+		} else {
+			n, err := strconv.Atoi(val)
+			if err == nil && n > 0 {
+				m.options.L3CacheAssocDie[dieIdx] = n
+			}
+		}
+		return
+	}
 	m.setStringField(fieldName, val)
 }
 
@@ -314,6 +340,22 @@ func parseL3CacheSizeDieField(name string) int {
 		return -1
 	}
 	suffix := strings.TrimPrefix(name, "L3CacheSizeDie")
+	if suffix == "" {
+		return -1
+	}
+	idx, err := strconv.Atoi(suffix)
+	if err != nil {
+		return -1
+	}
+	return idx
+}
+
+// parseL3CacheAssocDieField extracts die index from "L3CacheAssocDie<N>" or returns -1.
+func parseL3CacheAssocDieField(name string) int {
+	if !strings.HasPrefix(name, "L3CacheAssocDie") {
+		return -1
+	}
+	suffix := strings.TrimPrefix(name, "L3CacheAssocDie")
 	if suffix == "" {
 		return -1
 	}

--- a/internal/tui/models/cpu_options_form_navigation.go
+++ b/internal/tui/models/cpu_options_form_navigation.go
@@ -114,7 +114,7 @@ func (m *CPUOptionsFormModel) BuildPositions() []form.FocusPos {
 		Data: cpuOptFocusData{kind: int(form.FocusToggle), fieldName: "L3Cache"},
 	})
 
-	// Per-die L3 cache size override fields
+	// Per-die L3 cache override fields
 	if m.scanErr == nil && len(m.hostTopo.Dies) > 0 {
 		positions = append(positions, form.FocusPos{
 			Kind: form.FocusHeader, Label: "== Per-Die L3 Cache Override ==", Key: "header_l3_die",
@@ -128,6 +128,12 @@ func (m *CPUOptionsFormModel) BuildPositions() []form.FocusPos {
 			positions = append(positions, form.FocusPos{
 				Kind: form.FocusText, Label: label, Key: fieldKey,
 				Data: cpuOptFocusData{kind: int(form.FocusText), fieldName: fieldKey},
+			})
+			assocLabel := fmt.Sprintf("Die %d L3 cache associativity (e.g. 12)", die.ID)
+			assocKey := fmt.Sprintf("L3CacheAssocDie%d", die.ID)
+			positions = append(positions, form.FocusPos{
+				Kind: form.FocusText, Label: assocLabel, Key: assocKey,
+				Data: cpuOptFocusData{kind: int(form.FocusText), fieldName: assocKey},
 			})
 		}
 	}

--- a/internal/tui/models/cpu_options_form_render.go
+++ b/internal/tui/models/cpu_options_form_render.go
@@ -242,7 +242,11 @@ func (m *CPUOptionsFormModel) fieldLabel(name string) string {
 	}
 	// Handle dynamic L3CacheSizeDie<N> fields
 	if dieIdx := parseL3CacheSizeDieField(name); dieIdx >= 0 {
-		return fmt.Sprintf("Die %d L3 cache override", dieIdx)
+		return fmt.Sprintf("Die %d L3 cache size override", dieIdx)
+	}
+	// Handle dynamic L3CacheAssocDie<N> fields
+	if dieIdx := parseL3CacheAssocDieField(name); dieIdx >= 0 {
+		return fmt.Sprintf("Die %d L3 cache associativity override", dieIdx)
 	}
 	return name
 }

--- a/internal/tui/models/cpu_options_form_test.go
+++ b/internal/tui/models/cpu_options_form_test.go
@@ -388,6 +388,72 @@ func TestCPUOptionsFormWithL3CacheSizeDie(t *testing.T) {
 	}
 }
 
+// TestCPUOptionsFormWithL3CacheAssocDie tests per-die L3 cache associativity fields in form
+func TestCPUOptionsFormWithL3CacheAssocDie(t *testing.T) {
+	vmManager := createTestVMManager(t)
+	repo := vmManager.Repository()
+
+	f := NewCPUOptionsFormModelWithTopo(repo, models.HostCPUTopology{
+		Dies: []models.CPUDie{
+			{ID: 0, L3CacheKB: 32768},
+			{ID: 1, L3CacheKB: 98304},
+		},
+	}, nil)
+
+	// Find die L3 cache associativity fields
+	var die0Idx, die1Idx int = -1, -1
+	for i, p := range f.positions {
+		if p.Key == "L3CacheAssocDie0" {
+			die0Idx = i
+		}
+		if p.Key == "L3CacheAssocDie1" {
+			die1Idx = i
+		}
+	}
+
+	if die0Idx < 0 {
+		t.Error("Expected L3CacheAssocDie0 field in positions")
+	}
+	if die1Idx < 0 {
+		t.Error("Expected L3CacheAssocDie1 field in positions")
+	}
+
+	if die0Idx >= 0 {
+		// Check it's a text field
+		if f.positions[die0Idx].Kind != form.FocusText {
+			t.Errorf("L3CacheAssocDie0 kind = %d, want FocusText", f.positions[die0Idx].Kind)
+		}
+		// Check label mentions die
+		label := f.positions[die0Idx].Label
+		if !strings.Contains(label, "Die 0") {
+			t.Errorf("L3CacheAssocDie0 label = %q, should mention Die 0", label)
+		}
+	}
+
+	// Test editing die 0 L3 cache associativity
+	f.focusIndex = die0Idx
+	f.handleCharInput("8")
+	if f.getTextValue("L3CacheAssocDie0") != "8" {
+		t.Errorf("After typing '8', L3CacheAssocDie0 = %q, want 8", f.getTextValue("L3CacheAssocDie0"))
+	}
+
+	// Verify it's stored in the map
+	if f.options.L3CacheAssocDie[0] != 8 {
+		t.Errorf("L3CacheAssocDie[0] = %d, want 8", f.options.L3CacheAssocDie[0])
+	}
+
+	// Test clearing by backspace
+	f.focusIndex = die0Idx
+	f.handleBackspaceKey()
+	if f.getTextValue("L3CacheAssocDie0") != "" {
+		t.Errorf("After backspace, L3CacheAssocDie0 = %q, want empty", f.getTextValue("L3CacheAssocDie0"))
+	}
+	// Entry should be deleted from map, not just empty string
+	if _, exists := f.options.L3CacheAssocDie[0]; exists {
+		t.Errorf("L3CacheAssocDie[0] should be deleted after clearing")
+	}
+}
+
 // createTestVMManager creates a temporary VM manager for testing
 func createTestVMManager(t *testing.T) *vm.Manager {
 	t.Helper()

--- a/internal/vm/vm_runner_config.go
+++ b/internal/vm/vm_runner_config.go
@@ -377,6 +377,16 @@ func (r *VMRunner) buildCPUOptsString() string {
 			flags = append(flags, fmt.Sprintf("l3-cache-size-die%d=%s", dieIdx, size))
 		}
 	}
+	dieIndices = make([]int, 0, len(opts.L3CacheAssocDie))
+	for dieIdx := range opts.L3CacheAssocDie {
+		dieIndices = append(dieIndices, dieIdx)
+	}
+	sort.Ints(dieIndices)
+	for _, dieIdx := range dieIndices {
+		if assoc := opts.L3CacheAssocDie[dieIdx]; assoc > 0 {
+			flags = append(flags, fmt.Sprintf("l3-cache-assoc-die%d=%d", dieIdx, assoc))
+		}
+	}
 	if opts.X2APIC {
 		flags = append(flags, "+x2apic")
 	}

--- a/internal/vm/vm_runner_test.go
+++ b/internal/vm/vm_runner_test.go
@@ -1175,6 +1175,42 @@ func TestBuildCPUOptsStringWithL3CacheSizeDieEmpty(t *testing.T) {
 	}
 }
 
+func TestBuildCPUOptsStringWithL3CacheAssocDie(t *testing.T) {
+	runner := &VMRunner{
+		vm:     &models.VM{Name: "test"},
+		runCfg: RunConfig{CPUOptions: models.CPUOptions{
+			L3CacheAssocDie: map[int]int{
+				0: 8,
+				1: 12,
+			},
+		}},
+	}
+
+	result := runner.buildCPUOptsString()
+
+	if !containsString(result, "l3-cache-assoc-die0=8") {
+		t.Errorf("Expected l3-cache-assoc-die0=8 flag, got: %s", result)
+	}
+	if !containsString(result, "l3-cache-assoc-die1=12") {
+		t.Errorf("Expected l3-cache-assoc-die1=12 flag, got: %s", result)
+	}
+}
+
+func TestBuildCPUOptsStringWithL3CacheAssocDieEmpty(t *testing.T) {
+	runner := &VMRunner{
+		vm:     &models.VM{Name: "test"},
+		runCfg: RunConfig{CPUOptions: models.CPUOptions{
+			L3CacheAssocDie: map[int]int{},
+		}},
+	}
+
+	result := runner.buildCPUOptsString()
+
+	if containsString(result, "l3-cache-assoc-die") {
+		t.Errorf("Expected no l3-cache-assoc-die flags for empty map, got: %s", result)
+	}
+}
+
 func TestBuildQEMUArgsWithHostTopology(t *testing.T) {
 	dir := t.TempDir()
 	vmDir := filepath.Join(dir, "vms", "1")


### PR DESCRIPTION
## What

Adds `L3CacheAssocDie` CPU option to set per-die L3 cache associativity
override flags for asymmetric AMD V-cache CPUs (9950X3D, EPYC).

Part of the dkvm-qemu custom CPU property family alongside `l3-cache-size-die<N>` (#79).

## Changes

- **Model**: new `L3CacheAssocDie map[int]int` field in `CPUOptions` (key=die index 0..7, value=associativity)
- **QEMU arg emission**: emits `l3-cache-assoc-die<N>=<value>` after size flags in sorted die order
- **TUI form**: per-die associativity text fields alongside size fields in the Per-Die L3 Cache Override section
- **Tests**: QEMU arg emission tests + TUI form field interaction tests

Closes #80