### PR TITLE
fix: move WindowSizeMsg handler before registry dispatch (#84)

### DIFF
--- a/internal/tui/models/key_handlers.go
+++ b/internal/tui/models/key_handlers.go
@@ -142,6 +142,19 @@ func (m *MainModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return HandleLVCreateUpdatedMsg(m, msg)
 	}
 
+	// Handle WindowSizeMsg before registry dispatch so windowWidth/windowHeight
+	// are always updated even when a sub-view is active. The registry dispatch
+	// below would otherwise swallow this message and leave the dimensions at 0,
+	// causing SetSize to be called with negative/invalid values later.
+	if wm, ok := msg.(tea.WindowSizeMsg); ok {
+		m.windowWidth = wm.Width
+		m.windowHeight = wm.Height
+		// Forward to active sub-view so viewport can resize
+		m.forwardWindowSizeToSubView(wm)
+		// List sizing is done in render methods based on contentHeight()
+		return m, nil
+	}
+
 	// VMRunning-specific messages (polling/log) must bypass the registry dispatch
 	// because the registry calls cmd() synchronously and feeds the result through
 	// handleSubViewMsg, which breaks the command chain for Tick-based polling and
@@ -211,13 +224,6 @@ func (m *MainModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
 		return m.handleKeyPress(msg)
-	case tea.WindowSizeMsg:
-		m.windowWidth = msg.Width
-		m.windowHeight = msg.Height
-		// Forward to active sub-view so viewport can resize
-		m.forwardWindowSizeToSubView(msg)
-		// List sizing is done in render methods based on contentHeight()
-		return m, nil
 	}
 
 	return m, nil


### PR DESCRIPTION
## Description

When the mount point warning is active (e.g., `/media/dkvmdata` not mounted), the registry dispatch in `update()` intercepts the first `WindowSizeMsg` sent by BubbleTea at startup. Since the warning model doesn't handle `WindowSizeMsg`, the message is consumed but `windowWidth`/`windowHeight` remain at zero.

Later, `SetSize()` is called with `0-4 = -4` width, breaking all config sub-views (Set SSH Password, CPU Options, PCI Passthrough, etc.).

## Fix

Moved `WindowSizeMsg` handler **before** the registry dispatch block in `internal/tui/models/key_handlers.go`. Removed the now-dead duplicate handler from the bottom switch.

## Verification

All 12 test suites pass. Tested via tmux:

- Mount point warning appears → dismissed with Enter
- Configuration tab renders correctly with all items
- Add VM form renders with proper layout
- Set SSH Password form renders with strength indicator and [Apply] button
- No negative width/SetSize errors in debug log

Fixes #84