### PR TITLE
feat: detect host L3 cache associativity and show in CPU options form

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -90,6 +90,7 @@ type CPUDie struct {
 	Threads     int       `json:"threads" yaml:"threads"`           // Threads per core
 	LogicalCPUs []int     `json:"logical_cpus" yaml:"logical_cpus"` // Logical CPU IDs on this die
 	L3CacheKB   int       `json:"l3_cache_kb" yaml:"l3_cache_kb"`   // L3 cache size in KB
+	L3CacheAssoc int      `json:"l3_cache_assoc" yaml:"l3_cache_assoc"` // L3 cache associativity (ways)
 	CoreDetails []CPUCore `json:"core_details" yaml:"core_details"` // Per-core thread details
 }
 

--- a/internal/tui/models/cpu_options_form_navigation.go
+++ b/internal/tui/models/cpu_options_form_navigation.go
@@ -130,6 +130,9 @@ func (m *CPUOptionsFormModel) BuildPositions() []form.FocusPos {
 				Data: cpuOptFocusData{kind: int(form.FocusText), fieldName: fieldKey},
 			})
 			assocLabel := fmt.Sprintf("Die %d L3 cache associativity (e.g. 12)", die.ID)
+			if die.L3CacheAssoc > 0 {
+				assocLabel += fmt.Sprintf(" — detected: %d", die.L3CacheAssoc)
+			}
 			assocKey := fmt.Sprintf("L3CacheAssocDie%d", die.ID)
 			positions = append(positions, form.FocusPos{
 				Kind: form.FocusText, Label: assocLabel, Key: assocKey,

--- a/internal/vm/cpu_scanner.go
+++ b/internal/vm/cpu_scanner.go
@@ -259,11 +259,12 @@ func (s *CPUScanner) readThreadSiblings(cpuDir string) []int {
 	return parseIntList(strings.TrimSpace(string(data)))
 }
 
-// readL3CacheAssoc reads the L3 cache ways_of_associativity for a given die from sysfs
-func (s *CPUScanner) readL3CacheAssoc(dieID int) int {
+// findL3CacheIndexPath finds the sysfs cache index path (e.g., .../cpu0/cache/index0)
+// for the L3 cache of the given die. Returns empty string on failure.
+func (s *CPUScanner) findL3CacheIndexPath(dieID int) string {
 	cpuDirs, err := s.findOnlineCPUDirs()
 	if err != nil || len(cpuDirs) == 0 {
-		return 0
+		return ""
 	}
 
 	// Find a CPU in this die
@@ -276,13 +277,13 @@ func (s *CPUScanner) readL3CacheAssoc(dieID int) int {
 		}
 	}
 	if targetDir == "" {
-		targetDir = cpuDirs[0]
+		return ""
 	}
 
 	cacheDir := filepath.Join(targetDir, "cache")
 	cacheEntries, err := os.ReadDir(cacheDir)
 	if err != nil {
-		return 0
+		return ""
 	}
 
 	for _, entry := range cacheEntries {
@@ -292,81 +293,47 @@ func (s *CPUScanner) readL3CacheAssoc(dieID int) int {
 		indexPath := filepath.Join(cacheDir, entry.Name())
 
 		// Check if this is L3 cache
-		typeData, err := os.ReadFile(filepath.Join(indexPath, "level"))
+		levelData, err := os.ReadFile(filepath.Join(indexPath, "level"))
 		if err != nil {
 			continue
 		}
-		if strings.TrimSpace(string(typeData)) != "3" {
+		if strings.TrimSpace(string(levelData)) != "3" {
 			continue
 		}
-
-		// Read ways_of_associativity
-		assocData, err := os.ReadFile(filepath.Join(indexPath, "ways_of_associativity"))
-		if err != nil {
-			continue
-		}
-		val, err := strconv.Atoi(strings.TrimSpace(string(assocData)))
-		if err != nil {
-			return 0
-		}
-		return val
+		return indexPath
 	}
 
-	return 0
+	return ""
+}
+
+// readL3CacheAssoc reads the L3 cache ways_of_associativity for a given die from sysfs
+func (s *CPUScanner) readL3CacheAssoc(dieID int) int {
+	indexPath := s.findL3CacheIndexPath(dieID)
+	if indexPath == "" {
+		return 0
+	}
+	assocData, err := os.ReadFile(filepath.Join(indexPath, "ways_of_associativity"))
+	if err != nil {
+		return 0
+	}
+	val, err := strconv.Atoi(strings.TrimSpace(string(assocData)))
+	if err != nil {
+		return 0
+	}
+	return val
 }
 
 // readL3CacheKB reads the L3 cache size for a given die from sysfs
 func (s *CPUScanner) readL3CacheKB(dieID int) int {
-	// L3 cache is shared per die. Find it by scanning cache/index* for type "Unified"
-	// We look at cpu0's cache dirs (or the first cpu of the die)
-	cpuDirs, err := s.findOnlineCPUDirs()
-	if err != nil || len(cpuDirs) == 0 {
+	indexPath := s.findL3CacheIndexPath(dieID)
+	if indexPath == "" {
 		return 0
 	}
-
-	// Find a CPU in this die
-	targetDir := ""
-	for _, dir := range cpuDirs {
-		die := s.readSysfsInt(filepath.Join(dir, "topology", "die_id"))
-		if die == dieID {
-			targetDir = dir
-			break
-		}
-	}
-	if targetDir == "" {
-		targetDir = cpuDirs[0]
-	}
-
-	cacheDir := filepath.Join(targetDir, "cache")
-	cacheEntries, err := os.ReadDir(cacheDir)
+	sizeData, err := os.ReadFile(filepath.Join(indexPath, "size"))
 	if err != nil {
 		return 0
 	}
-
-	for _, entry := range cacheEntries {
-		if !entry.IsDir() {
-			continue
-		}
-		indexPath := filepath.Join(cacheDir, entry.Name())
-
-		// Check if this is L3 cache
-		typeData, err := os.ReadFile(filepath.Join(indexPath, "level"))
-		if err != nil {
-			continue
-		}
-		if strings.TrimSpace(string(typeData)) != "3" {
-			continue
-		}
-
-		// Read size
-		sizeData, err := os.ReadFile(filepath.Join(indexPath, "size"))
-		if err != nil {
-			continue
-		}
-		return parseCacheSizeKB(strings.TrimSpace(string(sizeData)))
-	}
-
-	return 0
+	return parseCacheSizeKB(strings.TrimSpace(string(sizeData)))
 }
 
 // parseIntList parses a comma-separated list of integers and ranges (e.g., "0-3,7")

--- a/internal/vm/cpu_scanner.go
+++ b/internal/vm/cpu_scanner.go
@@ -106,9 +106,10 @@ func (s *CPUScanner) ScanTopology() (models.HostCPUTopology, error) {
 		die, ok := dieMap[cpu.dieID]
 		if !ok {
 			die = &models.CPUDie{
-				ID:        cpu.dieID,
-				Threads:   threadsPerCore,
-				L3CacheKB: s.readL3CacheKB(cpu.dieID),
+				ID:           cpu.dieID,
+				Threads:      threadsPerCore,
+				L3CacheKB:    s.readL3CacheKB(cpu.dieID),
+				L3CacheAssoc: s.readL3CacheAssoc(cpu.dieID),
 			}
 			dieMap[cpu.dieID] = die
 		}
@@ -256,6 +257,62 @@ func (s *CPUScanner) readThreadSiblings(cpuDir string) []int {
 		return nil
 	}
 	return parseIntList(strings.TrimSpace(string(data)))
+}
+
+// readL3CacheAssoc reads the L3 cache ways_of_associativity for a given die from sysfs
+func (s *CPUScanner) readL3CacheAssoc(dieID int) int {
+	cpuDirs, err := s.findOnlineCPUDirs()
+	if err != nil || len(cpuDirs) == 0 {
+		return 0
+	}
+
+	// Find a CPU in this die
+	targetDir := ""
+	for _, dir := range cpuDirs {
+		die := s.readSysfsInt(filepath.Join(dir, "topology", "die_id"))
+		if die == dieID {
+			targetDir = dir
+			break
+		}
+	}
+	if targetDir == "" {
+		targetDir = cpuDirs[0]
+	}
+
+	cacheDir := filepath.Join(targetDir, "cache")
+	cacheEntries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		return 0
+	}
+
+	for _, entry := range cacheEntries {
+		if !entry.IsDir() {
+			continue
+		}
+		indexPath := filepath.Join(cacheDir, entry.Name())
+
+		// Check if this is L3 cache
+		typeData, err := os.ReadFile(filepath.Join(indexPath, "level"))
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(string(typeData)) != "3" {
+			continue
+		}
+
+		// Read ways_of_associativity
+		assocData, err := os.ReadFile(filepath.Join(indexPath, "ways_of_associativity"))
+		if err != nil {
+			continue
+		}
+		val, err := strconv.Atoi(strings.TrimSpace(string(assocData)))
+		if err != nil {
+			return 0
+		}
+		return val
+	}
+
+	return 0
 }
 
 // readL3CacheKB reads the L3 cache size for a given die from sysfs

--- a/internal/vm/cpu_scanner_test.go
+++ b/internal/vm/cpu_scanner_test.go
@@ -52,6 +52,7 @@ func createMockSysfs(t *testing.T) string {
 			os.MkdirAll(cacheDir, 0755)
 			os.WriteFile(filepath.Join(cacheDir, "level"), []byte("3\n"), 0644)
 			os.WriteFile(filepath.Join(cacheDir, "size"), []byte("32M\n"), 0644)
+			os.WriteFile(filepath.Join(cacheDir, "ways_of_associativity"), []byte("16\n"), 0644)
 		}
 	}
 
@@ -112,6 +113,9 @@ func TestCPUScannerScanTopology(t *testing.T) {
 	}
 	if die0.L3CacheKB != 32768 {
 		t.Errorf("Die[0].L3CacheKB = %d, want 32768", die0.L3CacheKB)
+	}
+	if die0.L3CacheAssoc != 16 {
+		t.Errorf("Die[0].L3CacheAssoc = %d, want 16", die0.L3CacheAssoc)
 	}
 
 	// Die 1
@@ -262,6 +266,7 @@ func TestCPUScannerAsymmetricL3(t *testing.T) {
 			cacheDir := filepath.Join(cpuDir, "cache", "index0")
 			os.MkdirAll(cacheDir, 0755)
 			os.WriteFile(filepath.Join(cacheDir, "level"), []byte("3\n"), 0644)
+			os.WriteFile(filepath.Join(cacheDir, "ways_of_associativity"), []byte("16\n"), 0644)
 			if dieID == 0 {
 				os.WriteFile(filepath.Join(cacheDir, "size"), []byte("32M\n"), 0644)
 			} else {
@@ -283,8 +288,14 @@ func TestCPUScannerAsymmetricL3(t *testing.T) {
 	if topo.Dies[0].L3CacheKB != 32768 {
 		t.Errorf("Die[0].L3CacheKB = %d, want 32768 (32M)", topo.Dies[0].L3CacheKB)
 	}
+	if topo.Dies[0].L3CacheAssoc != 16 {
+		t.Errorf("Die[0].L3CacheAssoc = %d, want 16", topo.Dies[0].L3CacheAssoc)
+	}
 	if topo.Dies[1].L3CacheKB != 98304 {
 		t.Errorf("Die[1].L3CacheKB = %d, want 98304 (96M)", topo.Dies[1].L3CacheKB)
+	}
+	if topo.Dies[1].L3CacheAssoc != 16 {
+		t.Errorf("Die[1].L3CacheAssoc = %d, want 16", topo.Dies[1].L3CacheAssoc)
 	}
 }
 


### PR DESCRIPTION
Closes #86

Changes:
- Add `L3CacheAssoc int` field to `CPUDie` struct
- Add `readL3CacheAssoc(dieID int) int` to `CPUScanner` (reads `ways_of_associativity` from sysfs)
- Call `readL3CacheAssoc` during `ScanTopology` to populate new field
- Show `— detected: <value>` in per-die associativity field label
- Add `ways_of_associativity` to test fixtures and verify new field in scanner tests