### PR TITLE
docs: consolidate documentation — add missing pages, link orphans, polish README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # DKVM Manager
 
+[![Go version](https://img.shields.io/github/go-mod/go-version/glemsom/dkvmmanager)](https://github.com/glemsom/dkvmmanager/blob/main/go.mod)
+[![License](https://img.shields.io/github/license/glemsom/dkvmmanager)](LICENSE)
+[![Latest release](https://img.shields.io/github/v/release/glemsom/dkvmmanager)](https://github.com/glemsom/dkvmmanager/releases/latest)
+[![Build status](https://img.shields.io/github/actions/workflow/status/glemsom/dkvmmanager/release-please.yml?branch=main)](https://github.com/glemsom/dkvmmanager/actions)
+
 Terminal UI for managing KVM/QEMU virtual machines on a single Linux host.
 
 > **Part of [DKVM](https://github.com/glemsom/dkvm)** — a KVM-based hypervisor for single-host virtualization. DKVM Manager is the TUI frontend for the DKVM stack.
@@ -15,30 +20,56 @@ Built with Go and [BubbleTea](https://github.com/charmbracelet/bubbletea), offer
 - **Scripts & SSH** — start/stop hook scripts and SSH password management
 - **Power management** — system power off, reboot, and LBU commit for persisting configuration
 
+## Installation
+
+### From GitHub Releases (recommended)
+
+Download the latest pre-built binary for Linux amd64:
+
+```bash
+curl -LO https://github.com/glemsom/dkvmmanager/releases/latest/download/dkvmmanager-linux-amd64
+chmod +x dkvmmanager-linux-amd64
+sudo mv dkvmmanager-linux-amd64 /usr/local/bin/dkvmmanager
+```
+
+Verify the installation:
+
+```bash
+dkvmmanager --help
+```
+
+### Build from Source
+
+Requires Go 1.26+ and Docker:
+
+```bash
+make build
+```
+
+The binary is produced at `./dkvmmanager`.
+
+### Alpine Linux (DKVM host)
+
+On the [DKVM](https://github.com/glemsom/dkvm) hypervisor, install directly:
+
+```bash
+apk add dkvmmanager
+```
+
 ## Quick Start
 
 ```bash
-# Build
-make build
-
-# Run
-./dkvmmanager
+# Run (after installation)
+dkvmmanager
 
 # With debug logging
-./dkvmmanager -debug
+dkvmmanager -debug
 
 # Dry-run (build QEMU command without executing)
-./dkvmmanager -dry-run
+dkvmmanager -dry-run
 ```
 
-### CLI Flags
-
-| Flag | Purpose |
-|------|---------|
-| `-debug` | Verbose logging to `debug.log` |
-| `-dry-run` | Build QEMU command but don't execute |
-| `-test <scenario>` | Run test scenario and exit |
-| `-skip-mount-check` | Skip `/media/dkvmdata` mount point check |
+See [CLI Flags Reference](docs/reference/cli-flags.md) for all available flags.
 
 ### Minimum Requirements
 
@@ -60,6 +91,10 @@ make build
 | [Running VMs](docs/user/running-vms.md) | VM runtime — log viewer, status, metrics, stopping |
 | [Power & Save](docs/user/power-and-save.md) | Power off, reboot, and saving configuration changes (LBU commit) |
 | [Keybindings](docs/user/keybindings.md) | Complete keyboard reference for the TUI |
+| [FAQ](docs/user/faq.md) | Frequently asked questions |
+| [Troubleshooting](docs/user/troubleshooting.md) | Common issues and solutions |
+| [CLI Flags Reference](docs/reference/cli-flags.md) | All command-line flags and options |
+| [Example Scripts](examples/README.md) | Reference scripts for PCI passthrough |
 | [User Guide Index](docs/user/README.md) | Overview of all user documentation |
 
 ### Developer Documentation

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -201,3 +201,4 @@ make build         # via Docker (golang:1.26-alpine)
 - [CONTEXT.md](../../CONTEXT.md) — domain glossary
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) — contribution workflow
 - [ADR 0001: Runner owns the running-VM data plane](../adr/0001-runner-owned-running-vm-data-plane.md) — key architectural decision
+- [Charmbracelet v2 Migration Audit](../charmbracelet-v2-migration-audit.md) — detailed API change checklist for BubbleTea v1→v2 migration

--- a/docs/reference/cli-flags.md
+++ b/docs/reference/cli-flags.md
@@ -1,0 +1,94 @@
+# CLI Flags Reference
+
+Command-line flags for DKVM Manager.
+
+All flags are defined in `main.go` and parsed by Go's `flag` package.
+
+---
+
+## Flag Table
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `-debug` | `bool` | `false` | Enable debug mode with verbose logging to `debug.log` |
+| `-dry-run` | `bool` | `false` | Build QEMU command but don't execute it |
+| `-test <scenario>` | `string` | `""` | Run a test scenario and exit |
+| `-skip-mount-check` | `bool` | `false` | Skip `/media/dkvmdata` mount point check |
+
+> **Source:** `main.go` lines 18–26
+
+---
+
+## `-debug`
+
+Enables verbose debug output. When set:
+
+- `tea.LogToFile()` redirects all `log.*` output to `debug.log` (tries CWD, then HOME, then `/tmp`)
+- BubbleTea's **AltScreen is disabled** — the TUI renders on stderr so debug log output is visible without switching screen buffers
+- All log output is suppressed from the terminal to avoid TUI corruption
+
+```bash
+./dkvmmanager -debug
+```
+
+> **Source:** `main.go` → `setupDebugLog()`; `internal/tui/tui.go` → `Run()`
+
+---
+
+## `-dry-run`
+
+Builds the QEMU command-line for a VM but does not execute it. The command is written to the VM log. Useful for:
+
+- Verifying QEMU arguments before running
+- Debugging PCI passthrough device addresses
+- Testing script execution flow without launching QEMU
+
+```bash
+./dkvmmanager -dry-run
+```
+
+> **Source:** `internal/vm/vm_runner.go` — checked at VM start; `internal/tui/models/init.go` → `SetDryRunMode()`
+
+---
+
+## `-test <scenario>`
+
+Runs a specific test scenario and exits. Available scenarios:
+
+| Scenario | What it does |
+|----------|-------------|
+| `main_menu` | Launches the main menu TUI for manual testing |
+| `vm_create` | Opens the VM creation form directly |
+
+```bash
+./dkvmmanager -test main_menu
+./dkvmmanager -test vm_create
+```
+
+> **Source:** `internal/tui/tui.go` → `Run()` — scenario dispatch
+
+---
+
+## `-skip-mount-check`
+
+Skips the startup check that verifies `/media/dkvmdata` is a real mount point. Use for:
+
+- Testing on systems without the DKVM data volume
+- Development environments
+- Running from a plain directory
+
+```bash
+./dkvmmanager -skip-mount-check
+```
+
+A warning is still logged to `debug.log` but no modal appears.
+
+> **Source:** `internal/tui/models/mount_point_warning.go` → `isMountPoint()`
+
+---
+
+## See Also
+
+- [Setup & Prerequisites](../user/setup.md) — system requirements and first launch
+- [Troubleshooting](../user/troubleshooting.md) — common issues
+- [User Guide Index](../user/README.md) — all documentation

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -23,6 +23,8 @@ See [CONTEXT.md](../CONTEXT.md) for the project domain glossary.
 | [Running VMs](running-vms.md) | VM runtime: log viewer, status, metrics, stopping |
 | [Power & Save](power-and-save.md) | Power off, reboot, and saving configuration changes (LBU commit) |
 | [Keybindings](keybindings.md) | Complete keyboard reference for the TUI |
+| [FAQ](faq.md) | Frequently asked questions |
+| [Troubleshooting](troubleshooting.md) | Common issues and solutions |
 
 ## Quick Reference
 

--- a/docs/user/faq.md
+++ b/docs/user/faq.md
@@ -1,0 +1,95 @@
+# Frequently Asked Questions
+
+Common questions about DKVM Manager.
+
+---
+
+## Can I run multiple VMs at the same time?
+
+No. DKVM Manager is a single-host, single-VM-at-a-time tool. One QEMU process runs at most. Starting a VM while another is running returns an error.
+
+> **Source:** `internal/vm/vm_runner.go` — single runner instance per session
+
+---
+
+## Where is my VM config stored?
+
+All VM configurations are in `/media/dkvmdata/dkvmmanager/config.yaml`. This is a YAML file read at startup and updated when you create, edit, or delete VMs.
+
+> **Source:** `internal/config/config.go` — `VmsConfigFile` default
+
+---
+
+## Why do I need to run `lbu commit`?
+
+DKVM runs on Alpine Linux in **diskless mode**. The entire filesystem lives in RAM (overlay). Changes to configuration, SSH passwords, and scripts are lost on reboot unless persisted.
+
+`lbu commit` writes the overlay changes to persistent storage. See [Power & Save](power-and-save.md) for details.
+
+> **Source:** `internal/tui/models/power_and_save.go` — LBU commit logic
+
+---
+
+## Do I need the DKVM hypervisor to use DKVM Manager?
+
+Yes. DKVM Manager is part of the [DKVM](https://github.com/glemsom/dkvm) stack. It depends on:
+- The DKVM data folder layout (`/media/dkvmdata`)
+- The DKVM diskless boot and overlay persistence model
+- The DKVM mount point convention (filesystem label `dkvmdata`)
+
+It is not a standalone general-purpose QEMU management tool.
+
+---
+
+## What terminal emulator do I need?
+
+Any 80×25 terminal that supports basic ANSI escape codes and UTF-8 works:
+
+- **Linux console TTY** (TERM=linux) — uses CP437 box-drawing characters
+- **xterm**, **kitty**, **alacritty**, **GNOME Terminal**, **Konsole** — all work
+- **tmux** / **screen** — work inside a terminal that meets the above requirements
+
+> **Source:** `docs/terminal-capabilities.md` — full analysis of terminal requirements
+
+---
+
+## How do I SSH into the host?
+
+Use Configuration → **Set SSH Password** (index 9) to set or change the host password. This runs `chpasswd` and persists with `lbu commit`. Then SSH in normally:
+
+```bash
+ssh user@host-ip
+```
+
+> **Source:** [Scripts & SSH](scripts-and-ssh.md) → SSH Password section
+
+---
+
+## Can I use DKVM Manager without IOMMU?
+
+Yes. CPU topology configuration, VM creation, editing, and management all work without IOMMU. Only **PCI passthrough** requires IOMMU support (VT-d / AMD-Vi).
+
+> **Source:** `docs/user/setup.md` → IOMMU section
+
+---
+
+## What happens if I Ctrl+C while a VM is running?
+
+Pressing `Ctrl+C` sends SIGKILL to the QEMU process — equivalent to yanking the power cord. The VM stops immediately without graceful shutdown.
+
+**Use `q` instead** for graceful shutdown (`system_powerdown` via QMP). See [Running VMs](running-vms.md).
+
+---
+
+## Does DKVM Manager support UEFI or legacy BIOS?
+
+DKVM Manager uses **OVMF (UEFI)** firmware only. Each VM gets a copy of `OVMF_CODE.fd` and `OVMF_VARS.fd`. Legacy BIOS/SeaBIOS is not supported.
+
+> **Source:** `internal/config/config.go` — `BiosCode`, `BiosVars` defaults
+
+---
+
+## See Also
+
+- [Troubleshooting](troubleshooting.md) — common issues and solutions
+- [User Guide Index](README.md) — all documentation

--- a/docs/user/scripts-and-ssh.md
+++ b/docs/user/scripts-and-ssh.md
@@ -202,4 +202,5 @@ Both forms use the shared `ScrollableForm` framework from `internal/tui/models/f
 - [VM Management](vm-management.md) — creating and editing VMs
 - [Running VMs](running-vms.md) — VM lifecycle and script output in log viewer
 - [Hardware Configuration](hardware-config.md) — PCI passthrough device configuration (used by builtin scripts)
+- [Example Scripts](../../examples/README.md) — reference scripts for PCI passthrough
 - [Keybindings](keybindings.md) — complete keyboard reference

--- a/docs/user/setup.md
+++ b/docs/user/setup.md
@@ -241,16 +241,13 @@ mount -o remount,rw /media/usb
 
 ### CLI flags
 
-| Flag | Purpose |
-|------|---------|
-| `-debug` | Enable verbose logging to `debug.log` (disables AltScreen, renders on stderr) |
-| `-dry-run` | Build QEMU command but don't execute it |
-| `-test <scenario>` | Run test scenario and exit (`main_menu`, `vm_create`) |
-| `-skip-mount-check` | Skip `/media/dkvmdata` mount point check |
+See [CLI Flags Reference](../reference/cli-flags.md) for all available flags.
 
 ### Minimum terminal
 
 DKVM requires 80×25 terminal. Warns on smaller sizes but allows continuing.
+
+See [Terminal Capabilities](../terminal-capabilities.md) for detailed analysis of terminal compatibility (box-drawing, CP437 support, color profiles).
 
 ### Debug mode details
 

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -1,0 +1,162 @@
+# Troubleshooting
+
+Common issues when using DKVM Manager, with symptoms, causes, and solutions.
+
+---
+
+## 1. Mount point check fails
+
+**Symptom:** Warning at startup: *"/media/dkvmdata is not a mount point"*
+
+**Cause:** DKVM Manager checks that `/media/dkvmdata` is a real mount point (device ID differs from parent). A plain directory passes the same device ID check and triggers the warning.
+
+**Solution:** Create a filesystem with `LABEL=dkvmdata` and mount it:
+
+```bash
+mkfs.ext4 -L dkvmdata /dev/sdX
+mount /dev/sdX /media/dkvmdata
+```
+
+For testing, skip the check with `-skip-mount-check`:
+
+```bash
+./dkvmmanager -skip-mount-check
+```
+
+> **Source:** `internal/tui/models/mount_point_warning.go` → `isMountPoint()`
+
+---
+
+## 2. Insufficient hugepages
+
+**Symptom:** Error message at startup: *"insufficient hugepages: have N, need M"*
+
+**Cause:** QEMU uses 2 MB hugepages for VM memory backing. The host has fewer reserved than needed.
+
+**Solution:** Reserve more hugepages temporarily:
+
+```bash
+echo 4096 > /proc/sys/vm/nr_hugepages
+```
+
+Or permanently via kernel command-line in GRUB (`/media/usb/boot/grub/grub.cfg`):
+
+```
+hugepages=4096
+```
+
+DKVM Manager's `hugepages.Ensure()` can auto-configure if run as root.
+
+> **Source:** `internal/hugepages/hugepages.go` → `NewAutoConfig()`, `Ensure()`, `FormatError()`
+
+---
+
+## 3. VM fails to start
+
+**Symptom:** VM creation succeeds but `Enter` on the VM in the list doesn't start it, or QEMU exits immediately.
+
+**Common causes:**
+
+| Cause | Check |
+|-------|-------|
+| QEMU binary not found | `which qemu-system-x86_64` — should return a path |
+| OVMF firmware missing | `ls /usr/share/OVMF/OVMF_CODE.fd` — configure path in `~/.dkvmmanager.yaml` |
+| swtpm not installed | `which swtpm` — needed when VM TPM is enabled |
+| Data folder permissions | `ls -la /media/dkvmdata/` — must be readable by the user running DKVM Manager |
+| VM name conflicts | Check `config.yaml` for duplicate names |
+
+> **Source:** `internal/vm/vm_runner.go` → `Start()`; `internal/config/config.go` → default paths
+
+---
+
+## 4. QMP connection timeout
+
+**Symptom:** `[STARTING]` badge never transitions to `[RUNNING]`. Log shows QEMU started but QMP connection failed.
+
+**Cause:** QEMU's QMP socket didn't become ready within the timeout period. Possible reasons:
+- QEMU process crashed immediately (see previous section)
+- Socket path is on a slow filesystem
+- Resource contention at startup
+
+**Solution:**
+1. Check `debug.log` for QEMU command-line and output
+2. Run with `-dry-run` to see the QEMU command without executing:
+   ```bash
+   ./dkvmmanager -dry-run
+   ```
+3. Try launching the generated QEMU command manually to see stderr
+
+> **Source:** `internal/vm/qmp_client.go` → QMP connection logic
+
+---
+
+## 5. Empty VM list after creation
+
+**Symptom:** Created a VM but the VMs tab shows nothing.
+
+**Cause:** DKVM Manager reads VM configuration from `/media/dkvmdata/dkvmmanager/config.yaml`. If this file is missing, inaccessible, or not a mount point, the list stays empty.
+
+**Solution:**
+1. Verify the data folder: `ls -la /media/dkvmdata/dkvmmanager/config.yaml`
+2. Ensure `/media/dkvmdata` is a mount point (see issue #1)
+3. Check file permissions — must be readable by your user
+4. Press `r` on the VMs tab to refresh
+
+> **Source:** `internal/vm/manager.go` → VM registry loading
+
+---
+
+## 6. LBU commit not found
+
+**Symptom:** "Save changes" in Configuration tab shows an error about `lbu` not found.
+
+**Cause:** DKVM Manager runs on Alpine Linux diskless mode. The `lbu` command is part of Alpine's `lbu` package and may not be installed on non-Alpine systems or minimal Alpine installs.
+
+**Solution:**
+```bash
+apk add lbu
+```
+
+> **Source:** `internal/tui/models/power_and_save.go` → LBU commit logic
+
+---
+
+## 7. PCI passthrough: device not found
+
+**Symptom:** In the PCI passthrough configuration screen, expected devices don't appear or fail to bind.
+
+**Causes and solutions:**
+
+| Problem | Check |
+|---------|-------|
+| IOMMU not enabled | `dmesg | grep -i iommu` — should show IOMMU enabled |
+| vfio-pci not loaded | `lsmod | grep vfio-pci` — load with `modprobe vfio-pci` |
+| BIOS setting disabled | Enable VT-d (Intel) or AMD-Vi (AMD) in BIOS/UEFI |
+| Device in wrong IOMMU group | `ls /sys/kernel/iommu_groups/*/devices/` — whole group must be passed together |
+
+> **Source:** `docs/user/setup.md` → IOMMU section; `internal/vm/discovery.go` → `ScanPCIDevices()`
+
+---
+
+## 8. Terminal too small
+
+**Symptom:** Warning: *"Terminal too small"* at startup.
+
+**Cause:** DKVM Manager requires an 80×25 terminal. Your terminal is smaller.
+
+**Solution:**
+- Resize the terminal window to at least 80 columns × 25 rows
+- Adjust font size to fit more characters
+- On the DKVM host console, check font configuration
+
+The warning is non-fatal — you can continue, but some views may not render correctly.
+
+> **Source:** `internal/tui/tui.go` → `validateAndLogTerminalSize()`
+
+---
+
+## See Also
+
+- [Setup & Prerequisites](setup.md) — system requirements and configuration
+- [FAQ](faq.md) — frequently asked questions
+- [Tutorial](tutorial.md) — step-by-step guide to your first VM

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,91 @@
+# Example Scripts
+
+Reference scripts for PCI passthrough configuration with DKVM Manager.
+
+---
+
+## `amd_ryzen_start_stop.sh`
+
+AMD Ryzen GPU passthrough start/stop script.
+
+**Purpose:** Binds and unbinds PCI devices for GPU passthrough on AMD Ryzen systems. Handles amdgpu driver cycling required by AMD GPUs.
+
+**Prerequisites:**
+- AMD Ryzen system with integrated GPU (iGPU) + discrete GPU (dGPU)
+- IOMMU enabled (VT-d/AMD-Vi)
+- `vfio-pci` kernel module loaded
+
+**Usage:**
+
+```bash
+./amd_ryzen_start_stop.sh start 0000:01:00.0 0000:02:00.0
+./amd_ryzen_start_stop.sh stop  0000:01:00.0 0000:02:00.0
+```
+
+**What it does:**
+- `start`: Protects iGPU from amdgpu via `driver_override`, reloads amdgpu for dGPU, unbinds current drivers, binds devices to `vfio-pci`
+- `stop`: Unbinds devices from `vfio-pci`, cleans up iGPU driver overrides
+
+**Configuration in DKVM Manager:**
+Set Configuration → **Edit Start/Stop Script** → Mode: **Custom**, point to this script path.
+
+> **Note:** This script is AMD-specific. The `driver_override` approach for iGPU protection may need adjustment for other vendors.
+
+---
+
+## `custom_pci_example.sh`
+
+Minimal example start/stop script for PCI passthrough.
+
+**Purpose:** Demonstrates the basic pattern for binding/unbinding PCI devices to `vfio-pci`. Simpler and vendor-agnostic compared to the AMD Ryzen script.
+
+**Prerequisites:**
+- PCI devices suitable for passthrough
+- `vfio-pci` kernel module loaded
+
+**Usage:**
+
+```bash
+./custom_pci_example.sh start 0000:01:00.0 0000:02:00.0
+./custom_pci_example.sh stop  0000:01:00.0 0000:02:00.0
+```
+
+**What it does:**
+- `start`: Unbinds each device from its current driver, binds to `vfio-pci`
+- `stop`: Unbinds each device from `vfio-pci` (driver re-assignment left to the system)
+
+**Configuration in DKVM Manager:**
+Set Configuration → **Edit Start/Stop Script** → Mode: **Custom**, point to this script path.
+
+---
+
+## Script Arguments
+
+Both scripts receive the same arguments from DKVM Manager:
+
+| Position | Value | Example |
+|----------|-------|---------|
+| `$1` | Command: `start` or `stop` | `start` |
+| `$2+` | PCI device addresses (0000:BB:DD.F format) | `0000:01:00.0` |
+
+---
+
+## DKVM Manager Integration
+
+These scripts are used as custom start/stop hooks. Configure them in the TUI:
+
+1. Switch to **Configuration** tab
+2. Select **Edit Start/Stop Script** (index 7)
+3. Toggle Mode to **Custom**
+4. Browse to or type the script path
+5. Save
+
+The runner executes the script before QEMU starts and after it stops. See [Scripts & SSH](../docs/user/scripts-and-ssh.md) for full details.
+
+---
+
+## See Also
+
+- [Scripts & SSH](../docs/user/scripts-and-ssh.md) — how to configure scripts in DKVM Manager
+- [Hardware Configuration](../docs/user/hardware-config.md) — PCI passthrough device configuration
+- [Setup & Prerequisites](../docs/user/setup.md) — IOMMU and vfio-pci setup


### PR DESCRIPTION
Closes #105, #106, #107, #108, #109, #111, #114, #115

## Changes

| Issue | What was done |
|-------|--------------|
| #105 | Fixed broken link — troubleshooting.md now exists |
| #106 | Linked orphaned files from index pages |
| #107 | Created troubleshooting guide (8 issues) |
| #108 | Added Installation section to README |
| #109 | Created FAQ page (9 questions) |
| #111 | Created CLI flags reference, removed inline tables |
| #114 | Added 4 badges to README header |
| #115 | Created examples/README.md |

**Files changed:** 9 files, +498 -20 lines