### PR TITLE
Rename internal/models -> internal/domain (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   topology that shows detected L3 cache associativity per die in the CPU options
   form. The CPU scanner now populates associativity alongside cache size.
   ([#86](https://github.com/glemsom/dkvmmanager/issues/86))
-  (`internal/models/models.go`, `internal/vm/cpu_scanner.go`,
+  (`internal/domain/models.go`, `internal/vm/cpu_scanner.go`,
   `internal/tui/models/cpu_options_form_navigation.go`)
 
 ### Fixed
@@ -69,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (9950X3D, EPYC). The CPU options form now shows per-die L3 cache size
   text fields with detected sizes from the host topology scanner.
   ([#79](https://github.com/glemsom/dkvmmanager/issues/79))
-  (`internal/models/models.go`, `internal/vm/vm_runner_config.go`,
+  (`internal/domain/models.go`, `internal/vm/vm_runner_config.go`,
   `internal/tui/models/cpu_options_form.go`,
   `internal/tui/models/cpu_options_form_navigation.go`,
   `internal/tui/models/cpu_options_form_render.go`)
@@ -224,7 +224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added rendering for the toggle in the form view
   - Added validation and save logic to persist `UseHostTopology` in the `CPUTopology` model
   - Added comprehensive tests for toggle navigation, rendering, and validation
-- **ForceCPUID0x80000026 toggle**: New CPU option to force CPUID leaf 0x80000026 (`internal/models/models.go`, `internal/tui/models/fields/cpu_options.go`, `internal/vm/repository.go`)
+- **ForceCPUID0x80000026 toggle**: New CPU option to force CPUID leaf 0x80000026 (`internal/domain/models.go`, `internal/tui/models/fields/cpu_options.go`, `internal/vm/repository.go`)
 - **Asymmetric vCPU topology mapper**: New `GenerateAsymmetricCPUDevices` function for building per-die CPU device declarations with correct APIC IDs (`internal/vm/vcpu_topology_mapper.go`)
 
 ### Fixed
@@ -236,7 +236,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.11] - 2026-05-05
 
 ### Added
-- **PCI bridge detection**: New `IsBridge` field on `PCIDevice` to identify PCI-to-PCI bridges (class code `0604`), enabling better device classification in the PCI passthrough form (`internal/models/models.go`, `internal/vm/pci_scanner.go`, `internal/tui/models/pci_passthrough_form.go`)
+- **PCI bridge detection**: New `IsBridge` field on `PCIDevice` to identify PCI-to-PCI bridges (class code `0604`), enabling better device classification in the PCI passthrough form (`internal/domain/models.go`, `internal/vm/pci_scanner.go`, `internal/tui/models/pci_passthrough_form.go`)
 
 ## [0.1.10] - 2026-05-04
 
@@ -300,7 +300,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **CPU Power Management toggle**: New `CPUPM` option in CPU options form to enable CPU power management passthrough (`cpu-pm=on`) to QEMU (`internal/models/models.go`, `internal/vm/vm_runner_config.go`, `internal/tui/models/cpu_options_form_*.go`)
+- **CPU Power Management toggle**: New `CPUPM` option in CPU options form to enable CPU power management passthrough (`cpu-pm=on`) to QEMU (`internal/domain/models.go`, `internal/vm/vm_runner_config.go`, `internal/tui/models/cpu_options_form_*.go`)
 
 ## [0.1.2](https://github.com/glemsom/dkvmmanager/compare/v0.1.1...v0.1.2) (2026-04-30)
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -11,7 +11,7 @@ Overview of DKVM Manager's internal architecture. Read `CONTEXT.md` first for do
 | `internal/tui/components` | Reusable UI components (tabs, status bar, breadcrumbs, dual pane, VM cards/table) |
 | `internal/tui/styles` | Lipgloss style definitions |
 | `internal/config` | Configuration file loading |
-| `internal/models` | Shared domain types (VM struct) |
+| `internal/domain` | Shared domain types (VM struct) |
 | `internal/hugepages` | Hugepage detection and configuration |
 | `internal/version` | Version constant |
 

--- a/docs/reference/vm-config.md
+++ b/docs/reference/vm-config.md
@@ -4,7 +4,7 @@ This file stores all VM definitions and global hardware configuration for DKVM M
 
 > **⚠️ Two configuration files — don't confuse them.** DKVM Manager uses **two separate YAML files** for different purposes. This document describes the VM config file. See [App Config Schema](app-config.md) for the application settings file at `~/.dkvmmanager.yaml`.
 
-> **Source:** `internal/vm/repository.go` — `Repository` (Viper-backed YAML store); `internal/models/models.go` — data model structs; `internal/vm/run_config.go` — `LoadRunConfigFromRepo()`.
+> **Source:** `internal/vm/repository.go` — `Repository` (Viper-backed YAML store); `internal/domain/models.go` — data model structs; `internal/vm/run_config.go` — `LoadRunConfigFromRepo()`.
 
 ---
 
@@ -77,7 +77,7 @@ vms:
     tpm_enabled: true
 ```
 
-> **Source:** `internal/models/models.go` — `VM` struct; `internal/vm/repository.go` — `SaveVM()`, `unmarshalVM()`.
+> **Source:** `internal/domain/models.go` — `VM` struct; `internal/vm/repository.go` — `SaveVM()`, `unmarshalVM()`.
 
 ---
 
@@ -112,7 +112,7 @@ pci_passthrough:
       class_code: "0403"
 ```
 
-> **Source:** `internal/models/models.go` — `PCIPassthroughDevice`, `PCIPassthroughConfig` structs.
+> **Source:** `internal/domain/models.go` — `PCIPassthroughDevice`, `PCIPassthroughConfig` structs.
 
 ---
 
@@ -142,7 +142,7 @@ usb_passthrough:
       bus_id: "1-3"
 ```
 
-> **Source:** `internal/models/models.go` — `USBPassthroughDevice`, `USBPassthroughConfig` structs.
+> **Source:** `internal/domain/models.go` — `USBPassthroughDevice`, `USBPassthroughConfig` structs.
 
 ---
 
@@ -165,7 +165,7 @@ cpu_topology:
   use_host_topology: true
 ```
 
-> **Source:** `internal/models/models.go` — `CPUTopology` struct.
+> **Source:** `internal/domain/models.go` — `CPUTopology` struct.
 
 ---
 
@@ -203,7 +203,7 @@ vcpu_pinning:
       host_cpu_id: 3
 ```
 
-> **Source:** `internal/models/models.go` — `VCPUPinningGlobal`, `VCPUToHostMapping` structs.
+> **Source:** `internal/domain/models.go` — `VCPUPinningGlobal`, `VCPUToHostMapping` structs.
 
 ---
 
@@ -257,7 +257,7 @@ cpu_options:
   rtc_utc: true
 ```
 
-> **Source:** `internal/models/models.go` — `CPUOptions` struct.
+> **Source:** `internal/domain/models.go` — `CPUOptions` struct.
 
 ---
 
@@ -280,7 +280,7 @@ custom_script:
   stop_script: /media/dkvmdata/vms/0/stop.sh
 ```
 
-> **Source:** `internal/models/models.go` — `StartStopScript` struct.
+> **Source:** `internal/domain/models.go` — `StartStopScript` struct.
 
 ---
 

--- a/docs/user/scripts-and-ssh.md
+++ b/docs/user/scripts-and-ssh.md
@@ -73,7 +73,7 @@ custom_script:
 
 Loaded by `LoadRunConfigFromRepo()` into `RunConfig.StartStopScript`.
 
-> **Source**: `internal/models/models.go` → `StartStopScript` struct; `internal/vm/run_config.go` → `LoadRunConfigFromRepo()`.
+> **Source**: `internal/domain/models.go` → `StartStopScript` struct; `internal/vm/run_config.go` → `LoadRunConfigFromRepo()`.
 
 ---
 

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -1,5 +1,5 @@
-// Package models provides data models for DKVM Manager
-package models
+// Package domain provides domain types for DKVM Manager
+package domain
 
 import "time"
 

--- a/internal/domain/types_test.go
+++ b/internal/domain/types_test.go
@@ -1,5 +1,5 @@
-// Package models provides tests for data models
-package models
+// Package domain provides tests for domain types
+package domain
 
 import (
 	"testing"

--- a/internal/tui/components/vm_cards.go
+++ b/internal/tui/components/vm_cards.go
@@ -7,13 +7,13 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/styles"
 )
 
 // VMCardView renders VMs as bordered cards instead of a table
 type VMCardView struct {
-	vms    []models.VM
+	vms    []domain.VM
 	cursor int
 	width  int
 	height int
@@ -21,7 +21,7 @@ type VMCardView struct {
 }
 
 // NewVMCardView creates a new VM card view
-func NewVMCardView(vms []models.VM, width, height int) *VMCardView {
+func NewVMCardView(vms []domain.VM, width, height int) *VMCardView {
 	return &VMCardView{
 		vms:    vms,
 		cursor: 0,
@@ -78,7 +78,7 @@ func (c *VMCardView) View() tea.View {
 }
 
 // renderCard renders a single VM as a bordered card
-func (c *VMCardView) renderCard(vm models.VM, selected bool) string {
+func (c *VMCardView) renderCard(vm domain.VM, selected bool) string {
 	cardWidth := c.width - 4
 	if cardWidth < 40 {
 		cardWidth = 40
@@ -165,7 +165,7 @@ func cardBorderChars() (topLeft, topRight, bottomLeft, bottomRight, horiz, vert 
 }
 
 // SelectedVM returns the currently selected VM
-func (c *VMCardView) SelectedVM() *models.VM {
+func (c *VMCardView) SelectedVM() *domain.VM {
 	if len(c.vms) == 0 || c.cursor < 0 || c.cursor >= len(c.vms) {
 		return nil
 	}
@@ -185,7 +185,7 @@ func (c *VMCardView) SetCursor(index int) {
 }
 
 // SetVMs updates the VM list
-func (c *VMCardView) SetVMs(vms []models.VM) {
+func (c *VMCardView) SetVMs(vms []domain.VM) {
 	c.vms = vms
 	if c.cursor >= len(vms) && len(vms) > 0 {
 		c.cursor = len(vms) - 1

--- a/internal/tui/components/vm_cards_test.go
+++ b/internal/tui/components/vm_cards_test.go
@@ -3,13 +3,13 @@ package components
 import (
 	"testing"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
-func makeTestVMs(count int) []models.VM {
-	vms := make([]models.VM, count)
+func makeTestVMs(count int) []domain.VM {
+	vms := make([]domain.VM, count)
 	for i := range vms {
-		vms[i] = models.VM{Name: "test-vm"}
+		vms[i] = domain.VM{Name: "test-vm"}
 	}
 	return vms
 }

--- a/internal/tui/components/vm_details.go
+++ b/internal/tui/components/vm_details.go
@@ -7,12 +7,12 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/styles"
 )
 
 type VMDetailsPanel struct {
-	vm     *models.VM
+	vm     *domain.VM
 	width  int
 	height int
 	title  string
@@ -29,7 +29,7 @@ func NewVMDetailsPanel() *VMDetailsPanel {
 	}
 }
 
-func (p *VMDetailsPanel) SetVM(vm *models.VM) {
+func (p *VMDetailsPanel) SetVM(vm *domain.VM) {
 	p.vm = vm
 }
 
@@ -247,7 +247,7 @@ func (p *VMDetailsPanel) renderActionBar(width int) string {
 	return actionBar
 }
 
-func (p *VMDetailsPanel) SelectedVM() *models.VM {
+func (p *VMDetailsPanel) SelectedVM() *domain.VM {
 	return p.vm
 }
 

--- a/internal/tui/components/vm_list_view.go
+++ b/internal/tui/components/vm_list_view.go
@@ -5,19 +5,19 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/styles"
 )
 
 type VMListView struct {
-	vms     []models.VM
+	vms     []domain.VM
 	cursor  int
 	width   int
 	height  int
 	focused bool
 }
 
-func NewVMListView(vms []models.VM, width, height int) *VMListView {
+func NewVMListView(vms []domain.VM, width, height int) *VMListView {
 	return &VMListView{
 		vms:     vms,
 		cursor:  0,
@@ -27,7 +27,7 @@ func NewVMListView(vms []models.VM, width, height int) *VMListView {
 	}
 }
 
-func (v *VMListView) SetVMs(vms []models.VM) {
+func (v *VMListView) SetVMs(vms []domain.VM) {
 	v.vms = vms
 	if v.cursor >= len(vms) && len(vms) > 0 {
 		v.cursor = len(vms) - 1
@@ -73,7 +73,7 @@ func (v *VMListView) MoveDown() bool {
 	return false
 }
 
-func (v *VMListView) SelectedVM() *models.VM {
+func (v *VMListView) SelectedVM() *domain.VM {
 	if v.cursor >= 0 && v.cursor < len(v.vms) {
 		return &v.vms[v.cursor]
 	}

--- a/internal/tui/components/vm_table.go
+++ b/internal/tui/components/vm_table.go
@@ -6,18 +6,18 @@ import (
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/styles"
 )
 
 // VMTable represents a table for displaying VM information
 type VMTable struct {
 	table table.Model
-	vms   []models.VM
+	vms   []domain.VM
 }
 
 // NewVMTable creates a new VM table
-func NewVMTable(vms []models.VM, width, height int) *VMTable {
+func NewVMTable(vms []domain.VM, width, height int) *VMTable {
 	columns := []table.Column{
 		{Title: "Name", Width: 25},
 		{Title: "ID", Width: 20},
@@ -59,7 +59,7 @@ func NewVMTable(vms []models.VM, width, height int) *VMTable {
 }
 
 // vmToRows converts VMs to table rows
-func vmToRows(vms []models.VM) []table.Row {
+func vmToRows(vms []domain.VM) []table.Row {
 	rows := make([]table.Row, len(vms))
 	for i, vm := range vms {
 		mac := vm.MAC
@@ -130,7 +130,7 @@ func (v *VMTable) View() tea.View {
 }
 
 // SelectedVM returns the currently selected VM
-func (v *VMTable) SelectedVM() *models.VM {
+func (v *VMTable) SelectedVM() *domain.VM {
 	if len(v.vms) == 0 {
 		return nil
 	}
@@ -142,7 +142,7 @@ func (v *VMTable) SelectedVM() *models.VM {
 }
 
 // SetVMs updates the VM list
-func (v *VMTable) SetVMs(vms []models.VM) {
+func (v *VMTable) SetVMs(vms []domain.VM) {
 	v.vms = vms
 	rows := vmToRows(vms)
 	v.table.SetRows(rows)

--- a/internal/tui/components/vm_table_test.go
+++ b/internal/tui/components/vm_table_test.go
@@ -4,11 +4,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 func TestNewVMTable(t *testing.T) {
-	vms := []models.VM{
+	vms := []domain.VM{
 		{ID: "vm-001", Name: "Test VM 1", MAC: "52:54:00:00:00:01"},
 		{ID: "vm-002", Name: "Test VM 2", MAC: "52:54:00:00:00:02"},
 	}
@@ -25,7 +25,7 @@ func TestNewVMTable(t *testing.T) {
 }
 
 func TestVMTableView(t *testing.T) {
-	vms := []models.VM{
+	vms := []domain.VM{
 		{ID: "vm-001", Name: "Test VM", MAC: "52:54:00:00:00:01"},
 	}
 
@@ -46,7 +46,7 @@ func TestVMTableView(t *testing.T) {
 }
 
 func TestVMTableSelectedVM(t *testing.T) {
-	vms := []models.VM{
+	vms := []domain.VM{
 		{ID: "vm-001", Name: "VM One"},
 		{ID: "vm-002", Name: "VM Two"},
 	}
@@ -64,7 +64,7 @@ func TestVMTableSelectedVM(t *testing.T) {
 }
 
 func TestVMTableSelectedVMEmpty(t *testing.T) {
-	table := NewVMTable([]models.VM{}, 80, 10)
+	table := NewVMTable([]domain.VM{}, 80, 10)
 
 	selected := table.SelectedVM()
 	if selected != nil {
@@ -73,13 +73,13 @@ func TestVMTableSelectedVMEmpty(t *testing.T) {
 }
 
 func TestVMTableSetVMs(t *testing.T) {
-	initial := []models.VM{
+	initial := []domain.VM{
 		{ID: "vm-001", Name: "Initial VM"},
 	}
 
 	table := NewVMTable(initial, 80, 10)
 
-	updated := []models.VM{
+	updated := []domain.VM{
 		{ID: "vm-002", Name: "Updated VM 1"},
 		{ID: "vm-003", Name: "Updated VM 2"},
 	}
@@ -97,7 +97,7 @@ func TestVMTableSetVMs(t *testing.T) {
 }
 
 func TestVMTableSetSize(t *testing.T) {
-	vms := []models.VM{
+	vms := []domain.VM{
 		{ID: "vm-001", Name: "Test VM"},
 	}
 
@@ -109,7 +109,7 @@ func TestVMTableSetSize(t *testing.T) {
 }
 
 func TestVMTableCursor(t *testing.T) {
-	vms := []models.VM{
+	vms := []domain.VM{
 		{ID: "vm-001", Name: "VM One"},
 		{ID: "vm-002", Name: "VM Two"},
 	}
@@ -122,7 +122,7 @@ func TestVMTableCursor(t *testing.T) {
 }
 
 func TestVMTableDisksColumn(t *testing.T) {
-	vms := []models.VM{
+	vms := []domain.VM{
 		{ID: "vm-001", Name: "Test VM", HardDisks: []string{"/dev/sda", "/dev/sdb"}},
 	}
 
@@ -135,7 +135,7 @@ func TestVMTableDisksColumn(t *testing.T) {
 }
 
 func TestVMTableEmptyMAC(t *testing.T) {
-	vms := []models.VM{
+	vms := []domain.VM{
 		{ID: "vm-001", Name: "Test VM"},
 	}
 

--- a/internal/tui/models/cpu_options_form.go
+++ b/internal/tui/models/cpu_options_form.go
@@ -8,7 +8,7 @@ import (
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/fields"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/vm"
@@ -18,10 +18,10 @@ import (
 // It implements the form.FormModel interface for use with ScrollableForm.
 type CPUOptionsFormModel struct {
 	repo    *vm.Repository
-	options *models.CPUOptions
+	options *domain.CPUOptions
 
 	// Host topology data (for per-die L3 cache override)
-	hostTopo models.HostCPUTopology
+	hostTopo domain.HostCPUTopology
 	scanErr  error
 
 	// Focus state
@@ -52,7 +52,7 @@ type CPUOptionsFormModel struct {
 
 // NewCPUOptionsFormModel creates a new CPU options form model
 func NewCPUOptionsFormModel(repo *vm.Repository) *CPUOptionsFormModel {
-	var opts models.CPUOptions
+	var opts domain.CPUOptions
 	repo.GetConfig("cpu_options", &opts)
 
 	// Scan host topology for per-die L3 cache info
@@ -75,8 +75,8 @@ func NewCPUOptionsFormModel(repo *vm.Repository) *CPUOptionsFormModel {
 
 // NewCPUOptionsFormModelWithTopo creates a form with explicit host topology (for testing).
 // Skips the host CPU scan and uses the provided topology data instead.
-func NewCPUOptionsFormModelWithTopo(repo *vm.Repository, hostTopo models.HostCPUTopology, scanErr error) *CPUOptionsFormModel {
-	var opts models.CPUOptions
+func NewCPUOptionsFormModelWithTopo(repo *vm.Repository, hostTopo domain.HostCPUTopology, scanErr error) *CPUOptionsFormModel {
+	var opts domain.CPUOptions
 	repo.GetConfig("cpu_options", &opts)
 
 	m := &CPUOptionsFormModel{

--- a/internal/tui/models/cpu_options_form_test.go
+++ b/internal/tui/models/cpu_options_form_test.go
@@ -8,7 +8,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/glemsom/dkvmmanager/internal/config"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/fields"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/vm"
@@ -198,7 +198,7 @@ func TestCPUOptionsFormSave(t *testing.T) {
 	}
 
 	// Verify saved options
-	var saved models.CPUOptions
+	var saved domain.CPUOptions
 	vmManager.Repository().GetConfig("cpu_options", &saved)
 	if !saved.HideKVM {
 		t.Errorf("Saved HideKVM = false, want true")
@@ -258,7 +258,7 @@ func (m *CPUOptionsFormModel) findIndexByName(name string) int {
 // TestCPUOptionsUpdateMsg tests that Update returns correct types
 func TestCPUOptionsUpdateMsg(t *testing.T) {
 	form := &CPUOptionsFormModel{
-		options:       &models.CPUOptions{},
+		options:       &domain.CPUOptions{},
 		cursorOffsets: make(map[string]int),
 		errors:        make(map[string]string),
 	}
@@ -276,7 +276,7 @@ func TestCPUOptionsUpdateMsg(t *testing.T) {
 // TestCPUOptionsFieldLabels tests that all fields have labels
 func TestCPUOptionsFieldLabels(t *testing.T) {
 	form := &CPUOptionsFormModel{
-		options:       &models.CPUOptions{},
+		options:       &domain.CPUOptions{},
 		cursorOffsets: make(map[string]int),
 		errors:        make(map[string]string),
 	}
@@ -300,7 +300,7 @@ func TestCPUOptionsFieldLabels(t *testing.T) {
 // TestCPUOptionsPositionsCount tests that BuildPositions creates correct number of positions
 func TestCPUOptionsPositionsCount(t *testing.T) {
 	form := &CPUOptionsFormModel{
-		options:       &models.CPUOptions{},
+		options:       &domain.CPUOptions{},
 		cursorOffsets: make(map[string]int),
 		errors:        make(map[string]string),
 	}
@@ -322,8 +322,8 @@ func TestCPUOptionsFormWithL3CacheSizeDie(t *testing.T) {
 	// The form scans topology at runtime, so we mock it by creating a form and
 	// directly providing hostTopo.
 
-	f := NewCPUOptionsFormModelWithTopo(repo, models.HostCPUTopology{
-		Dies: []models.CPUDie{
+	f := NewCPUOptionsFormModelWithTopo(repo, domain.HostCPUTopology{
+		Dies: []domain.CPUDie{
 			{ID: 0, L3CacheKB: 32768},
 			{ID: 1, L3CacheKB: 98304},
 		},
@@ -393,8 +393,8 @@ func TestCPUOptionsFormWithL3CacheAssocDie(t *testing.T) {
 	vmManager := createTestVMManager(t)
 	repo := vmManager.Repository()
 
-	f := NewCPUOptionsFormModelWithTopo(repo, models.HostCPUTopology{
-		Dies: []models.CPUDie{
+	f := NewCPUOptionsFormModelWithTopo(repo, domain.HostCPUTopology{
+		Dies: []domain.CPUDie{
 			{ID: 0, L3CacheKB: 32768},
 			{ID: 1, L3CacheKB: 98304},
 		},
@@ -459,8 +459,8 @@ func TestCPUOptionsFormL3CachePersistence(t *testing.T) {
 	vmManager := createTestVMManager(t)
 	repo := vmManager.Repository()
 
-	f := NewCPUOptionsFormModelWithTopo(repo, models.HostCPUTopology{
-		Dies: []models.CPUDie{
+	f := NewCPUOptionsFormModelWithTopo(repo, domain.HostCPUTopology{
+		Dies: []domain.CPUDie{
 			{ID: 0, L3CacheKB: 32768, L3CacheAssoc: 16},
 			{ID: 1, L3CacheKB: 98304, L3CacheAssoc: 12},
 		},
@@ -502,7 +502,7 @@ func TestCPUOptionsFormL3CachePersistence(t *testing.T) {
 	}
 
 	// Verify saved options directly via repo
-	var saved models.CPUOptions
+	var saved domain.CPUOptions
 	if err := repo.GetConfig("cpu_options", &saved); err != nil {
 		t.Fatalf("Failed to GetConfig: %v", err)
 	}
@@ -562,8 +562,8 @@ func TestCPUOptionsFormL3CachePersistence(t *testing.T) {
 	}
 
 	// Simulate re-entering form: create a new form and verify values
-	f2 := NewCPUOptionsFormModelWithTopo(repo, models.HostCPUTopology{
-		Dies: []models.CPUDie{
+	f2 := NewCPUOptionsFormModelWithTopo(repo, domain.HostCPUTopology{
+		Dies: []domain.CPUDie{
 			{ID: 0, L3CacheKB: 32768, L3CacheAssoc: 16},
 			{ID: 1, L3CacheKB: 98304, L3CacheAssoc: 12},
 		},

--- a/internal/tui/models/cpu_topology_form.go
+++ b/internal/tui/models/cpu_topology_form.go
@@ -7,7 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/vm"
 )
@@ -17,7 +17,7 @@ type cpuTopoFocusData struct {
 	dieID   int
 	coreID  int
 	dieLabel string
-	coreInfo *models.CPUCore
+	coreInfo *domain.CPUCore
 }
 
 // CPUTopologyFormModel is a scrollable form for editing global CPU topology.
@@ -26,10 +26,10 @@ type CPUTopologyFormModel struct {
 	repo *vm.Repository
 
 	// Host topology data
-	hostTopo models.HostCPUTopology
+	hostTopo domain.HostCPUTopology
 
 	// Global configuration
-	topology models.CPUTopology
+	topology domain.CPUTopology
 
 	// Quick lookup: coreKey (dieID:coreID) -> selected for VM
 	coreSelected map[string]bool
@@ -66,7 +66,7 @@ func NewCPUTopologyFormModel(repo *vm.Repository) (*CPUTopologyFormModel, error)
 	hostTopo, scanErr := scanner.ScanTopology()
 
 	// Load global CPU topology config
-	var topology models.CPUTopology
+	var topology domain.CPUTopology
 	err := repo.GetConfig("cpu_topology", &topology)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load CPU topology: %w", err)
@@ -132,7 +132,7 @@ type cpuTopoPos struct {
 	dieID    int
 	coreID   int
 	dieLabel string
-	coreInfo *models.CPUCore
+	coreInfo *domain.CPUCore
 }
 
 // Constants for backward compatibility with existing tests.

--- a/internal/tui/models/cpu_topology_form_render.go
+++ b/internal/tui/models/cpu_topology_form_render.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/tui/styles"
 )
@@ -127,7 +127,7 @@ func (m *CPUTopologyFormModel) renderAllLines() []string {
 }
 
 // renderCoreLine renders a physical core with its thread info
-func (m *CPUTopologyFormModel) renderCoreLine(core *models.CPUCore, selected, focused bool) string {
+func (m *CPUTopologyFormModel) renderCoreLine(core *domain.CPUCore, selected, focused bool) string {
 	prefix := "  "
 	if focused {
 		prefix = cpuTopoFocusStyle.Render("> ")

--- a/internal/tui/models/cpu_topology_form_test.go
+++ b/internal/tui/models/cpu_topology_form_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/vm"
 )
@@ -137,7 +137,7 @@ func TestCPUTopologyFormSave(t *testing.T) {
 	}
 
 	// Verify saved config
-	var savedTopo models.CPUTopology
+	var savedTopo domain.CPUTopology
 	vmManager.Repository().GetConfig("cpu_topology", &savedTopo)
 	if !savedTopo.Enabled {
 		t.Errorf("Saved CPUTopology.Enabled = false, want true")
@@ -318,4 +318,4 @@ func TestCPUTopologyFormModelInterface(t *testing.T) {
 var _ = vm.NewManager
 
 // Ensure models package is used
-var _ = models.CPUTopology{}
+var _ = domain.CPUTopology{}

--- a/internal/tui/models/cpu_topology_form_validation.go
+++ b/internal/tui/models/cpu_topology_form_validation.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 )
 
@@ -33,7 +33,7 @@ func (m *CPUTopologyFormModel) validateAndSaveCmd() (form.FormResult, tea.Cmd) {
 		return form.ResultNone, nil
 	}
 
-	topo := models.CPUTopology{
+	topo := domain.CPUTopology{
 		Enabled:      true,
 		SelectedCPUs: selectedCPUs,
 	}

--- a/internal/tui/models/list_adapter.go
+++ b/internal/tui/models/list_adapter.go
@@ -7,7 +7,7 @@ import (
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/styles"
 )
 
@@ -78,9 +78,9 @@ func (d MenuItemDelegate) Render(w io.Writer, m list.Model, index int, listItem 
 	fmt.Fprint(w, style.Render(str))
 }
 
-// VMListAdapter wraps models.VM to implement list.Item interface
+// VMListAdapter wraps domain.VM to implement list.Item interface
 type VMListAdapter struct {
-	models.VM
+	domain.VM
 }
 
 func (a VMListAdapter) FilterValue() string { return a.VM.Name }
@@ -124,7 +124,7 @@ func (d VMListItemDelegate) Render(w io.Writer, m list.Model, index int, listIte
 }
 
 // buildVMListAdapter converts VMs to list.Item slice
-func buildVMListAdapter(vms []models.VM) []list.Item {
+func buildVMListAdapter(vms []domain.VM) []list.Item {
 	listItems := make([]list.Item, len(vms))
 	for i, vm := range vms {
 		listItems[i] = VMListAdapter{VM: vm}

--- a/internal/tui/models/list_adapter_test.go
+++ b/internal/tui/models/list_adapter_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/list"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 func TestMenuItemAdapterFilterValue(t *testing.T) {
@@ -195,7 +195,7 @@ func TestMenuItemDelegateRenderInvalidType(t *testing.T) {
 
 func TestVMListAdapterFilterValue(t *testing.T) {
 	item := VMListAdapter{
-		VM: models.VM{
+		VM: domain.VM{
 			ID:   "vm-001",
 			Name: "Test VM",
 		},
@@ -208,7 +208,7 @@ func TestVMListAdapterFilterValue(t *testing.T) {
 
 func TestVMListAdapterTitle(t *testing.T) {
 	item := VMListAdapter{
-		VM: models.VM{
+		VM: domain.VM{
 			ID:   "vm-002",
 			Name: "My Virtual Machine",
 		},
@@ -222,12 +222,12 @@ func TestVMListAdapterTitle(t *testing.T) {
 func TestVMListAdapterDescription(t *testing.T) {
 	tests := []struct {
 		name string
-		vm   models.VM
+		vm   domain.VM
 		want string
 	}{
 		{
 			name: "VM with harddisks",
-			vm: models.VM{
+			vm: domain.VM{
 				ID:        "vm-001",
 				Name:      "Test",
 				HardDisks: []string{"/dev/sda", "/dev/sdb"},
@@ -236,7 +236,7 @@ func TestVMListAdapterDescription(t *testing.T) {
 		},
 		{
 			name: "VM with cdroms",
-			vm: models.VM{
+			vm: domain.VM{
 				ID:     "vm-002",
 				Name:   "Test",
 				CDROMs: []string{"/isos/ubuntu.iso"},
@@ -245,7 +245,7 @@ func TestVMListAdapterDescription(t *testing.T) {
 		},
 		{
 			name: "VM with both",
-			vm: models.VM{
+			vm: domain.VM{
 				ID:        "vm-003",
 				Name:      "Test",
 				HardDisks: []string{"/dev/sda"},
@@ -255,7 +255,7 @@ func TestVMListAdapterDescription(t *testing.T) {
 		},
 		{
 			name: "VM with no disks",
-			vm: models.VM{
+			vm: domain.VM{
 				ID:   "vm-004",
 				Name: "Test",
 			},
@@ -275,7 +275,7 @@ func TestVMListAdapterDescription(t *testing.T) {
 
 func TestVMListAdapterImplementsListItem(t *testing.T) {
 	item := VMListAdapter{
-		VM: models.VM{ID: "vm-001", Name: "Test"},
+		VM: domain.VM{ID: "vm-001", Name: "Test"},
 	}
 
 	// Compile-time check that VMListAdapter implements list.Item
@@ -312,7 +312,7 @@ func TestVMListItemDelegateImplementsItemDelegate(t *testing.T) {
 func TestVMListItemDelegateRenderSelected(t *testing.T) {
 	d := VMListItemDelegate{}
 	item := VMListAdapter{
-		VM: models.VM{ID: "vm-001", Name: "Test VM"},
+		VM: domain.VM{ID: "vm-001", Name: "Test VM"},
 	}
 
 	items := []list.Item{item}
@@ -334,10 +334,10 @@ func TestVMListItemDelegateRenderSelected(t *testing.T) {
 func TestVMListItemDelegateRenderUnselected(t *testing.T) {
 	d := VMListItemDelegate{}
 	item1 := VMListAdapter{
-		VM: models.VM{ID: "vm-001", Name: "Item 1"},
+		VM: domain.VM{ID: "vm-001", Name: "Item 1"},
 	}
 	item2 := VMListAdapter{
-		VM: models.VM{ID: "vm-002", Name: "Item 2"},
+		VM: domain.VM{ID: "vm-002", Name: "Item 2"},
 	}
 
 	items := []list.Item{item1, item2}
@@ -368,7 +368,7 @@ func TestVMListItemDelegateRenderInvalidType(t *testing.T) {
 }
 
 func TestBuildVMListAdapter(t *testing.T) {
-	vms := []models.VM{
+	vms := []domain.VM{
 		{ID: "vm-001", Name: "Alpha"},
 		{ID: "vm-002", Name: "Beta"},
 		{ID: "vm-003", Name: "Gamma"},

--- a/internal/tui/models/main_test.go
+++ b/internal/tui/models/main_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/glemsom/dkvmmanager/internal/config"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // hasFilesRecursive returns true if dir or any of its subdirectories
@@ -271,4 +271,4 @@ func TestVMDeletedMsgStruct(t *testing.T) {
 }
 
 // Ensure the VM model used in tests is valid
-var _ models.VM = models.VM{}
+var _ domain.VM = domain.VM{}

--- a/internal/tui/models/pci_passthrough_form.go
+++ b/internal/tui/models/pci_passthrough_form.go
@@ -7,15 +7,15 @@ import (
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/vm"
 )
 
 // filterPCIBridges removes PCI bridge devices (switch ports, root ports) from the list.
 // Bridges should never be passed through directly — only end devices are valid targets.
-func filterPCIBridges(devices []models.PCIDevice) []models.PCIDevice {
-	var filtered []models.PCIDevice
+func filterPCIBridges(devices []domain.PCIDevice) []domain.PCIDevice {
+	var filtered []domain.PCIDevice
 	for _, d := range devices {
 		if !d.IsBridge {
 			filtered = append(filtered, d)
@@ -30,13 +30,13 @@ type PCIPassthroughFormModel struct {
 	repo          *vm.Repository
 	vmManager     *vm.Manager
 	hostDiscovery vm.HostDiscovery
-	devices       []models.PCIDevice          // All scanned devices
-	config    models.PCIPassthroughConfig // Current config (selected devices)
+	devices       []domain.PCIDevice          // All scanned devices
+	config    domain.PCIPassthroughConfig // Current config (selected devices)
 	selected  map[string]bool             // Quick lookup: address -> selected
 
 	// IOMMU group index: group number -> list of device pointers
 	// Group -1 represents ungrouped devices
-	iommuGroups map[int][]*models.PCIDevice
+	iommuGroups map[int][]*domain.PCIDevice
 
 	// Focus state
 	positions  []form.FocusPos
@@ -71,7 +71,7 @@ func NewPCIPassthroughFormModel(repo *vm.Repository, vmManager *vm.Manager, host
 	allDevices, scanErr := hostDiscovery.ScanPCIDevices()
 
 	// Load existing config
-	var cfg models.PCIPassthroughConfig
+	var cfg domain.PCIPassthroughConfig
 	repo.GetConfig("pci_passthrough", &cfg)
 
 	// Build lookup maps
@@ -99,7 +99,7 @@ func NewPCIPassthroughFormModel(repo *vm.Repository, vmManager *vm.Manager, host
 // buildIOMMUGroups indexes devices by IOMMU group number.
 // Devices with IOMMUGroup < 0 are placed in the -1 (ungrouped) bucket.
 func (m *PCIPassthroughFormModel) buildIOMMUGroups() {
-	m.iommuGroups = make(map[int][]*models.PCIDevice)
+	m.iommuGroups = make(map[int][]*domain.PCIDevice)
 	for i := range m.devices {
 		dev := &m.devices[i]
 		group := dev.IOMMUGroup

--- a/internal/tui/models/pci_passthrough_form_navigation.go
+++ b/internal/tui/models/pci_passthrough_form_navigation.go
@@ -4,7 +4,7 @@ package models
 import (
 	"strconv"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 )
 
@@ -89,7 +89,7 @@ func (m *PCIPassthroughFormModel) currentPos() form.FocusPos {
 }
 
 // getDeviceByAddr finds a device by PCI address
-func (m *PCIPassthroughFormModel) getDeviceByAddr(addr string) *models.PCIDevice {
+func (m *PCIPassthroughFormModel) getDeviceByAddr(addr string) *domain.PCIDevice {
 	for i := range m.devices {
 		if m.devices[i].Address == addr {
 			return &m.devices[i]

--- a/internal/tui/models/pci_passthrough_form_render.go
+++ b/internal/tui/models/pci_passthrough_form_render.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/tui/styles"
 )
@@ -140,7 +140,7 @@ func (m *PCIPassthroughFormModel) RenderPosition(pos form.FocusPos, focused bool
 
 // renderDeviceToggle renders a PCI device as a toggle line.
 // Format: [X] 0000:01:00.0 [GPU] NVIDIA GeForce GTX 1080 [10de:1b80] (IOMMU:1)
-func (m *PCIPassthroughFormModel) renderDeviceToggle(dev *models.PCIDevice, selected, focused bool) string {
+func (m *PCIPassthroughFormModel) renderDeviceToggle(dev *domain.PCIDevice, selected, focused bool) string {
 	prefix := "  "
 	if focused {
 		prefix = pciFocusStyle.Render("> ")

--- a/internal/tui/models/pci_passthrough_form_test.go
+++ b/internal/tui/models/pci_passthrough_form_test.go
@@ -5,31 +5,31 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 )
 
 // noopHostDiscovery is a test double that returns empty scans
 type noopHostDiscovery struct{}
 
-func (noopHostDiscovery) ScanPCIDevices() ([]models.PCIDevice, error) {
+func (noopHostDiscovery) ScanPCIDevices() ([]domain.PCIDevice, error) {
 	return nil, nil
 }
 
-func (noopHostDiscovery) ScanUSBDevices() ([]models.USBDevice, error) {
+func (noopHostDiscovery) ScanUSBDevices() ([]domain.USBDevice, error) {
 	return nil, nil
 }
 
-func (noopHostDiscovery) ScanCPUTopology() (models.HostCPUTopology, error) {
-	return models.HostCPUTopology{}, nil
+func (noopHostDiscovery) ScanCPUTopology() (domain.HostCPUTopology, error) {
+	return domain.HostCPUTopology{}, nil
 }
 
 // --- Test Fixtures ---
 
 // mockPCIDevices returns a deterministic set of PCI devices for testing
 // IOMMU groups: Group 1 (GPU + audio), Group 2 (USB), Group -1 (ungrouped)
-func mockPCIDevices() []models.PCIDevice {
-	return []models.PCIDevice{
+func mockPCIDevices() []domain.PCIDevice {
+	return []domain.PCIDevice{
 		{
 			Address:    "0000:01:00.0",
 			Vendor:     "10de",
@@ -498,7 +498,7 @@ func TestPCIFORMSavePreservesSelectedDevices(t *testing.T) {
 	}
 
 	// Verify saved config
-	var saved models.PCIPassthroughConfig
+	var saved domain.PCIPassthroughConfig
 	if err := m.repo.GetConfig("pci_passthrough", &saved); err != nil {
 		t.Fatalf("Failed to load saved PCI config: %v", err)
 	}
@@ -532,7 +532,7 @@ func TestPCIFORMNoROMInSavedConfig(t *testing.T) {
 	}
 	cmd()
 
-	var saved models.PCIPassthroughConfig
+	var saved domain.PCIPassthroughConfig
 	if err := m.repo.GetConfig("pci_passthrough", &saved); err != nil {
 		t.Fatalf("Failed to load saved PCI config: %v", err)
 	}
@@ -552,10 +552,10 @@ func TestPCIFORMEmptyDevices(t *testing.T) {
 		repo:          vmManager.Repository(),
 		vmManager:     vmManager,
 		hostDiscovery: &noopHostDiscovery{},
-		devices:       []models.PCIDevice{},
+		devices:       []domain.PCIDevice{},
 		selected:    make(map[string]bool),
 		errors:      make(map[string]string),
-		iommuGroups: make(map[int][]*models.PCIDevice),
+		iommuGroups: make(map[int][]*domain.PCIDevice),
 	}
 	m.BuildPositions()
 	m.Update(tea.WindowSizeMsg{Width: 80, Height: 25})
@@ -580,10 +580,10 @@ func TestPCIFORMViewShowsNoDevicesMessage(t *testing.T) {
 		repo:          vmManager.Repository(),
 		vmManager:     vmManager,
 		hostDiscovery: &noopHostDiscovery{},
-		devices:       []models.PCIDevice{},
+		devices:       []domain.PCIDevice{},
 		selected:    make(map[string]bool),
 		errors:      make(map[string]string),
-		iommuGroups: make(map[int][]*models.PCIDevice),
+		iommuGroups: make(map[int][]*domain.PCIDevice),
 	}
 	m.BuildPositions()
 	m.Update(tea.WindowSizeMsg{Width: 80, Height: 25})
@@ -889,7 +889,7 @@ func TestPCIFORMSelectMultipleGroups(t *testing.T) {
 	}
 	cmd()
 
-	var saved models.PCIPassthroughConfig
+	var saved domain.PCIPassthroughConfig
 	if err := m.repo.GetConfig("pci_passthrough", &saved); err != nil {
 		t.Fatalf("Failed to load saved PCI config: %v", err)
 	}
@@ -988,7 +988,7 @@ func TestPCIPassthroughFormModelInterface(t *testing.T) {
 
 // TestFilterPCIBridges verifies that PCI bridge devices are filtered out
 func TestFilterPCIBridges(t *testing.T) {
-	devices := []models.PCIDevice{
+	devices := []domain.PCIDevice{
 		{
 			Address:   "0000:01:00.0",
 			Name:      "NVIDIA GeForce GTX 1080",
@@ -1051,13 +1051,13 @@ func TestFilterPCIBridges(t *testing.T) {
 // TestFilterPCIBridgesEmptyAndAllBridges verifies edge cases
 func TestFilterPCIBridgesEmptyAndAllBridges(t *testing.T) {
 	// Empty input
-	filtered := filterPCIBridges([]models.PCIDevice{})
+	filtered := filterPCIBridges([]domain.PCIDevice{})
 	if len(filtered) != 0 {
 		t.Errorf("Empty input should yield empty output, got %d devices", len(filtered))
 	}
 
 	// All bridges
-	allBridges := []models.PCIDevice{
+	allBridges := []domain.PCIDevice{
 		{Address: "0000:01:00.0", ClassCode: "0604", IsBridge: true},
 		{Address: "0000:02:00.0", ClassCode: "0604", IsBridge: true},
 	}
@@ -1067,7 +1067,7 @@ func TestFilterPCIBridgesEmptyAndAllBridges(t *testing.T) {
 	}
 
 	// No bridges
-	noBridges := []models.PCIDevice{
+	noBridges := []domain.PCIDevice{
 		{Address: "0000:01:00.0", ClassCode: "0300", IsGPU: true},
 		{Address: "0000:02:00.0", ClassCode: "0c03", IsUSB: true},
 	}

--- a/internal/tui/models/pci_passthrough_form_validation.go
+++ b/internal/tui/models/pci_passthrough_form_validation.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/vm"
 )
@@ -17,12 +17,12 @@ func (m *PCIPassthroughFormModel) validateAndSaveCmd() (form.FormResult, tea.Cmd
 	m.warnings = nil
 
 	// Build config from selected devices
-	var devices []models.PCIPassthroughDevice
+	var devices []domain.PCIPassthroughDevice
 	for _, dev := range m.devices {
 		if !m.selected[dev.Address] {
 			continue
 		}
-		devices = append(devices, models.PCIPassthroughDevice{
+		devices = append(devices, domain.PCIPassthroughDevice{
 			Address:   dev.Address,
 			ROMPath:   "", // ROM field removed from UI; preserved for backward compatibility
 			Vendor:    dev.Vendor,
@@ -39,7 +39,7 @@ func (m *PCIPassthroughFormModel) validateAndSaveCmd() (form.FormResult, tea.Cmd
 		return form.ResultNone, nil
 	}
 
-	cfg := models.PCIPassthroughConfig{
+	cfg := domain.PCIPassthroughConfig{
 		Devices: devices,
 	}
 
@@ -63,12 +63,12 @@ func (m *PCIPassthroughFormModel) handleApplyKernelCmd() tea.Cmd {
 	m.kernelMsgErr = false
 
 	// Build config from selected devices (same as save)
-	var devices []models.PCIPassthroughDevice
+	var devices []domain.PCIPassthroughDevice
 	for _, dev := range m.devices {
 		if !m.selected[dev.Address] {
 			continue
 		}
-		devices = append(devices, models.PCIPassthroughDevice{
+		devices = append(devices, domain.PCIPassthroughDevice{
 			Address:   dev.Address,
 			ROMPath:   "",
 			Vendor:    dev.Vendor,
@@ -87,7 +87,7 @@ func (m *PCIPassthroughFormModel) handleApplyKernelCmd() tea.Cmd {
 	}
 
 	// Build the PCI passthrough config and save it first
-	cfg := models.PCIPassthroughConfig{
+	cfg := domain.PCIPassthroughConfig{
 		Devices: devices,
 	}
 	if err := m.repo.SaveConfig("pci_passthrough", cfg); err != nil {

--- a/internal/tui/models/start_stop_script_form.go
+++ b/internal/tui/models/start_stop_script_form.go
@@ -4,7 +4,7 @@ package models
 import (
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/vm"
 )
@@ -13,8 +13,8 @@ import (
 // It implements the form.FormModel interface for use with ScrollableForm.
 type StartStopScriptFormModel struct {
 	repo        *vm.Repository
-	config      models.StartStopScript
-	pciConfig models.PCIPassthroughConfig // For displaying in builtin mode
+	config      domain.StartStopScript
+	pciConfig domain.PCIPassthroughConfig // For displaying in builtin mode
 
 	// Focus state
 	positions  []form.FocusPos
@@ -41,9 +41,9 @@ type StartStopScriptFormModel struct {
 
 // NewStartStopScriptFormModel creates a new StartStopScript form model
 func NewStartStopScriptFormModel(repo *vm.Repository) (*StartStopScriptFormModel, error) {
-	var cfg models.StartStopScript
+	var cfg domain.StartStopScript
 	repo.GetConfig("custom_script", &cfg)
-	var pciCfg models.PCIPassthroughConfig
+	var pciCfg domain.PCIPassthroughConfig
 	repo.GetConfig("pci_passthrough", &pciCfg)
 
 	m := &StartStopScriptFormModel{

--- a/internal/tui/models/start_stop_script_form_test.go
+++ b/internal/tui/models/start_stop_script_form_test.go
@@ -8,7 +8,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/glemsom/dkvmmanager/internal/config"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/vm"
 )
@@ -273,8 +273,8 @@ func createTestVMManagerForScript(t *testing.T) *vm.Manager {
 	}
 
 	// Pre-populate some PCI config for display in builtin mode
-	pciCfg := models.PCIPassthroughConfig{
-		Devices: []models.PCIPassthroughDevice{
+	pciCfg := domain.PCIPassthroughConfig{
+		Devices: []domain.PCIPassthroughDevice{
 			{Address: "0000:01:00.0", Name: "NVIDIA GPU"},
 		},
 	}

--- a/internal/tui/models/types.go
+++ b/internal/tui/models/types.go
@@ -4,7 +4,7 @@ package models
 import (
 	"charm.land/bubbles/v2/list"
 	"github.com/glemsom/dkvmmanager/internal/config"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/components"
 	"github.com/glemsom/dkvmmanager/internal/vm"
 )
@@ -121,7 +121,7 @@ type MainModel struct {
 	runningVMID string
 
 	// VM list for selection
-	vmListForSelection []models.VM
+	vmListForSelection []domain.VM
 	vmSelectList       list.Model
 
 	// Selection mode (edit or delete)
@@ -150,5 +150,5 @@ type MenuItem struct {
 	Type     string // "VM", "INT_CONFIG", "INT_POWEROFF", "INT_SHELL"
 	VMID     string // VM ID if type is "VM"
 	Disabled bool
-	VMData   *models.VM
+	VMData   *domain.VM
 }

--- a/internal/tui/models/usb_passthrough_form.go
+++ b/internal/tui/models/usb_passthrough_form.go
@@ -7,7 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/tui/styles"
 	"github.com/glemsom/dkvmmanager/internal/vm"
@@ -23,8 +23,8 @@ func usbDeviceKey(vendor, product string) string {
 type USBPassthroughFormModel struct {
 	repo          *vm.Repository
 	hostDiscovery vm.HostDiscovery
-	devices       []models.USBDevice          // All scanned devices
-	config    models.USBPassthroughConfig // Current config (selected devices)
+	devices       []domain.USBDevice          // All scanned devices
+	config    domain.USBPassthroughConfig // Current config (selected devices)
 	selected  map[string]bool             // Quick lookup: vendor:product -> selected
 
 	// Focus state
@@ -56,7 +56,7 @@ func NewUSBPassthroughFormModel(repo *vm.Repository, hostDiscovery vm.HostDiscov
 	allDevices, scanErr := hostDiscovery.ScanUSBDevices()
 
 	// Load existing config
-	var cfg models.USBPassthroughConfig
+	var cfg domain.USBPassthroughConfig
 	repo.GetConfig("usb_passthrough", &cfg)
 
 	// Build lookup map
@@ -80,7 +80,7 @@ func NewUSBPassthroughFormModel(repo *vm.Repository, hostDiscovery vm.HostDiscov
 }
 
 // getDeviceByID finds a device by vendor:product key
-func (m *USBPassthroughFormModel) getDeviceByID(id string) *models.USBDevice {
+func (m *USBPassthroughFormModel) getDeviceByID(id string) *domain.USBDevice {
 	for i := range m.devices {
 		if usbDeviceKey(m.devices[i].Vendor, m.devices[i].Product) == id {
 			return &m.devices[i]

--- a/internal/tui/models/usb_passthrough_form_render.go
+++ b/internal/tui/models/usb_passthrough_form_render.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/tui/styles"
 )
@@ -84,7 +84,7 @@ func (m *USBPassthroughFormModel) RenderPosition(pos form.FocusPos, focused bool
 }
 
 // renderDeviceToggle renders a USB device as a toggle line.
-func (m *USBPassthroughFormModel) renderDeviceToggle(dev *models.USBDevice, selected, focused bool) string {
+func (m *USBPassthroughFormModel) renderDeviceToggle(dev *domain.USBDevice, selected, focused bool) string {
 	prefix := "  "
 	if focused {
 		prefix = usbFocusStyle.Render("> ")

--- a/internal/tui/models/usb_passthrough_form_test.go
+++ b/internal/tui/models/usb_passthrough_form_test.go
@@ -6,15 +6,15 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 )
 
 // --- Test Fixtures ---
 
 // mockUSBDevices returns a deterministic set of USB devices for testing
-func mockUSBDevices() []models.USBDevice {
-	return []models.USBDevice{
+func mockUSBDevices() []domain.USBDevice {
+	return []domain.USBDevice{
 		{Vendor: "046d", Product: "c52b", Name: "Logitech Unifying Receiver", ID: "1-1.2"},
 		{Vendor: "8087", Product: "0a2b", Name: "Intel Bluetooth", ID: "1-4"},
 		{Vendor: "0781", Product: "5567", Name: "SanDisk Cruzer Blade", ID: "2-1"},
@@ -343,7 +343,7 @@ func TestUSBViewShowsNoDevicesMessage(t *testing.T) {
 	m := &USBPassthroughFormModel{
 		repo:          vmManager.Repository(),
 		hostDiscovery: &noopHostDiscovery{},
-		devices:   []models.USBDevice{},
+		devices:   []domain.USBDevice{},
 		selected:  make(map[string]bool),
 		errors:    make(map[string]string),
 	}
@@ -396,7 +396,7 @@ func TestUSBFormEmptyDevices(t *testing.T) {
 	m := &USBPassthroughFormModel{
 		repo:          vmManager.Repository(),
 		hostDiscovery: &noopHostDiscovery{},
-		devices:   []models.USBDevice{},
+		devices:   []domain.USBDevice{},
 		selected:  make(map[string]bool),
 		errors:    make(map[string]string),
 	}

--- a/internal/tui/models/usb_passthrough_form_validation.go
+++ b/internal/tui/models/usb_passthrough_form_validation.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/vm"
 )
@@ -17,13 +17,13 @@ func (m *USBPassthroughFormModel) validateAndSaveCmd() (form.FormResult, tea.Cmd
 	m.warnings = nil
 
 	// Build config from selected devices
-	var devices []models.USBPassthroughDevice
+	var devices []domain.USBPassthroughDevice
 	for _, dev := range m.devices {
 		key := usbDeviceKey(dev.Vendor, dev.Product)
 		if !m.selected[key] {
 			continue
 		}
-		devices = append(devices, models.USBPassthroughDevice{
+		devices = append(devices, domain.USBPassthroughDevice{
 			Vendor:  dev.Vendor,
 			Product: dev.Product,
 			Name:    dev.Name,
@@ -38,7 +38,7 @@ func (m *USBPassthroughFormModel) validateAndSaveCmd() (form.FormResult, tea.Cmd
 		return form.ResultNone, nil
 	}
 
-	cfg := models.USBPassthroughConfig{
+	cfg := domain.USBPassthroughConfig{
 		Devices: devices,
 	}
 

--- a/internal/tui/models/vcpu_pinning_form.go
+++ b/internal/tui/models/vcpu_pinning_form.go
@@ -6,7 +6,7 @@ import (
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/vm"
 )
@@ -24,13 +24,13 @@ type VCPUPinningFormModel struct {
 	repo      *vm.Repository
 
 	// Host topology data (read-only, for display)
-	hostTopo models.HostCPUTopology
+	hostTopo domain.HostCPUTopology
 
 	// Global CPU topology (read-only, for computing pinning)
-	topology models.CPUTopology
+	topology domain.CPUTopology
 
 	// Global configuration
-	pinning models.VCPUPinningGlobal
+	pinning domain.VCPUPinningGlobal
 
 	// Use host topology toggle (stored in CPU topology config)
 	useHostTopology bool
@@ -66,14 +66,14 @@ func NewVCPUPinningFormModel(vmManager *vm.Manager, repo *vm.Repository) (*VCPUP
 	hostTopo, scanErr := scanner.ScanTopology()
 
 	// Load global CPU topology config (needed to compute pinning)
-	var topology models.CPUTopology
+	var topology domain.CPUTopology
 	err := repo.GetConfig("cpu_topology", &topology)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load CPU topology: %w", err)
 	}
 
 	// Load global vCPU pinning config
-	var pinning models.VCPUPinningGlobal
+	var pinning domain.VCPUPinningGlobal
 	err = repo.GetConfig("vcpu_pinning", &pinning)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load vcpu pinning: %w", err)

--- a/internal/tui/models/vcpu_pinning_form_test.go
+++ b/internal/tui/models/vcpu_pinning_form_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 )
 
@@ -333,12 +333,12 @@ func newTestVCPUPinningFormModel(t *testing.T) *VCPUPinningFormModel {
 	// Fallback: construct manually for environments without CPU topology
 	formModel = &VCPUPinningFormModel{
 		vmManager: vmManager,
-		hostTopo: models.HostCPUTopology{
-			Dies: []models.CPUDie{
+		hostTopo: domain.HostCPUTopology{
+			Dies: []domain.CPUDie{
 				{
 					ID:   0,
 					Cores: 4,
-					CoreDetails: []models.CPUCore{
+					CoreDetails: []domain.CPUCore{
 						{ID: 0, Threads: []int{0, 1}},
 						{ID: 1, Threads: []int{2, 3}},
 						{ID: 2, Threads: []int{4, 5}},
@@ -349,11 +349,11 @@ func newTestVCPUPinningFormModel(t *testing.T) *VCPUPinningFormModel {
 			TotalCores: 4,
 			TotalCPUs:  8,
 		},
-		topology: models.CPUTopology{
+		topology: domain.CPUTopology{
 			Enabled:      true,
 			SelectedCPUs: []int{0, 1, 2, 3},
 		},
-		pinning:    models.VCPUPinningGlobal{Enabled: false, Mappings: nil},
+		pinning:    domain.VCPUPinningGlobal{Enabled: false, Mappings: nil},
 		errors:     make(map[string]string),
 		focusIndex: 0,
 		scanErr:    nil,

--- a/internal/tui/models/view.go
+++ b/internal/tui/models/view.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/components"
 	"github.com/glemsom/dkvmmanager/internal/tui/styles"
 	"github.com/glemsom/dkvmmanager/internal/version"
@@ -175,7 +175,7 @@ func (m *MainModel) renderVMsTabWithWidth(width int) string {
 
 	m.menuList.SetSize(leftWidth, height)
 
-	var selectedVM *models.VM
+	var selectedVM *domain.VM
 	if m.selectedIndex >= 0 && m.selectedIndex < len(m.menuItems) {
 		selectedVM = m.menuItems[m.selectedIndex].VMData
 	}
@@ -195,7 +195,7 @@ func (m *MainModel) renderVMsTabWithWidth(width int) string {
 	return lipgloss.JoinHorizontal(lipgloss.Top, leftPanel, "  ", rightPanel)
 }
 
-func renderVMDetail(vm *models.VM, width, height int) string {
+func renderVMDetail(vm *domain.VM, width, height int) string {
 	headerStyle := styles.DetailHeaderStyle()
 	labelStyle := styles.DetailLabelStyle()
 	valueStyle := styles.DetailValueStyle()

--- a/internal/tui/models/vm_delete.go
+++ b/internal/tui/models/vm_delete.go
@@ -7,7 +7,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/styles"
 	"github.com/glemsom/dkvmmanager/internal/vm"
 )
@@ -18,7 +18,7 @@ type VMDeleteModel struct {
 	vmManager *vm.Manager
 
 	// VM to delete
-	vm *models.VM
+	vm *domain.VM
 
 	// Selected option (0 = No, 1 = Yes)
 	selectedIndex int

--- a/internal/tui/models/vm_edit.go
+++ b/internal/tui/models/vm_edit.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/vm"
 )
@@ -28,7 +28,7 @@ func NewVMEditModel(vmManager *vm.Manager, vmID string) (*VMEditModel, error) {
 		return nil, fmt.Errorf("failed to list VMs: %w", err)
 	}
 
-	var targetVM *models.VM
+	var targetVM *domain.VM
 	for i := range vms {
 		if vms[i].ID == vmID {
 			targetVM = &vms[i]

--- a/internal/tui/models/vm_form_model.go
+++ b/internal/tui/models/vm_form_model.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/models/form"
 	"github.com/glemsom/dkvmmanager/internal/tui/styles"
 	"github.com/glemsom/dkvmmanager/internal/vm"
@@ -17,7 +17,7 @@ import (
 type VMFormModel struct {
 	mode      FormMode
 	vmManager *vm.Manager
-	vm        *models.VM // non-nil only in edit mode
+	vm        *domain.VM // non-nil only in edit mode
 
 	// Field values
 	vmName      string
@@ -66,7 +66,7 @@ func NewVMFormModel(vmManager *vm.Manager) *VMFormModel {
 }
 
 // NewVMFormModelEdit creates a form in Edit mode pre-filled from an existing VM
-func NewVMFormModelEdit(vmManager *vm.Manager, vmObj *models.VM) *VMFormModel {
+func NewVMFormModelEdit(vmManager *vm.Manager, vmObj *domain.VM) *VMFormModel {
 	hd := vmObj.HardDisks
 	if len(hd) == 0 {
 		hd = []string{""}

--- a/internal/tui/models/vm_running.go
+++ b/internal/tui/models/vm_running.go
@@ -9,7 +9,7 @@ import (
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/tui/styles"
 	"github.com/glemsom/dkvmmanager/internal/vm"
 )
@@ -61,7 +61,7 @@ type VMMetricsUpdateMsg struct {
 // VMRunningModel displays a running VM with log output and status
 type VMRunningModel struct {
 	// VM info
-	vm     *models.VM
+	vm     *domain.VM
 	runner *vm.VMRunner
 
 	// Log viewport
@@ -94,7 +94,7 @@ type VMRunningModel struct {
 }
 
 // NewVMRunningModel creates a new VM running model
-func NewVMRunningModel(vmObj *models.VM, runner *vm.VMRunner) *VMRunningModel {
+func NewVMRunningModel(vmObj *domain.VM, runner *vm.VMRunner) *VMRunningModel {
 	return &VMRunningModel{
 		vm:          vmObj,
 		runner:      runner,

--- a/internal/tui/models/vm_running_test.go
+++ b/internal/tui/models/vm_running_test.go
@@ -7,13 +7,13 @@ import (
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
-	models "github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/glemsom/dkvmmanager/internal/vm"
 )
 
 func setupRunningModel(t *testing.T, status string) *VMRunningModel {
 	t.Helper()
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	return &VMRunningModel{
 		vm:          vmObj,
 		maxLogLines: 500,
@@ -784,7 +784,7 @@ func TestVMStartedMsgHandlerSetsRunner(t *testing.T) {
 	m := setupRunningModel(t, "starting")
 
 	// Create a real runner (with nil config, not used in this test)
-	runner := vm.NewVMRunner(&models.VM{Name: "test-vm", ID: "1"}, nil, vm.RunConfig{})
+	runner := vm.NewVMRunner(&domain.VM{Name: "test-vm", ID: "1"}, nil, vm.RunConfig{})
 
 	// Simulate receiving VMStartedMsg with a runner
 	msg := VMStartedMsg{

--- a/internal/vm/config_store_test.go
+++ b/internal/vm/config_store_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // TestConfigStore_RoundTrip verifies each config type survives a save-and-reload cycle
@@ -17,11 +17,11 @@ func TestConfigStore_RoundTrip(t *testing.T) {
 	}
 
 	t.Run("CPUOptions", func(t *testing.T) {
-		in := models.CPUOptions{HideKVM: true, HVRelaxed: true, VendorID: "GenuineIntel"}
+		in := domain.CPUOptions{HideKVM: true, HVRelaxed: true, VendorID: "GenuineIntel"}
 		if err := repo.SaveConfig("cpu_options", in); err != nil {
 			t.Fatal(err)
 		}
-		var out models.CPUOptions
+		var out domain.CPUOptions
 		if err := repo.GetConfig("cpu_options", &out); err != nil {
 			t.Fatal(err)
 		}
@@ -31,15 +31,15 @@ func TestConfigStore_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("PCIPassthroughConfig", func(t *testing.T) {
-		in := models.PCIPassthroughConfig{
-			Devices: []models.PCIPassthroughDevice{
+		in := domain.PCIPassthroughConfig{
+			Devices: []domain.PCIPassthroughDevice{
 				{Address: "0000:01:00.0", Vendor: "10de", Device: "1b80", Name: "GPU"},
 			},
 		}
 		if err := repo.SaveConfig("pci_passthrough", in); err != nil {
 			t.Fatal(err)
 		}
-		var out models.PCIPassthroughConfig
+		var out domain.PCIPassthroughConfig
 		if err := repo.GetConfig("pci_passthrough", &out); err != nil {
 			t.Fatal(err)
 		}
@@ -49,15 +49,15 @@ func TestConfigStore_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("USBPassthroughConfig", func(t *testing.T) {
-		in := models.USBPassthroughConfig{
-			Devices: []models.USBPassthroughDevice{
+		in := domain.USBPassthroughConfig{
+			Devices: []domain.USBPassthroughDevice{
 				{Vendor: "046d", Product: "c52b", Name: "Unifying Receiver"},
 			},
 		}
 		if err := repo.SaveConfig("usb_passthrough", in); err != nil {
 			t.Fatal(err)
 		}
-		var out models.USBPassthroughConfig
+		var out domain.USBPassthroughConfig
 		if err := repo.GetConfig("usb_passthrough", &out); err != nil {
 			t.Fatal(err)
 		}
@@ -67,11 +67,11 @@ func TestConfigStore_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("CPUTopology", func(t *testing.T) {
-		in := models.CPUTopology{Enabled: true, SelectedCPUs: []int{0, 1, 2, 3}}
+		in := domain.CPUTopology{Enabled: true, SelectedCPUs: []int{0, 1, 2, 3}}
 		if err := repo.SaveConfig("cpu_topology", in); err != nil {
 			t.Fatal(err)
 		}
-		var out models.CPUTopology
+		var out domain.CPUTopology
 		if err := repo.GetConfig("cpu_topology", &out); err != nil {
 			t.Fatal(err)
 		}
@@ -81,16 +81,16 @@ func TestConfigStore_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("VCPUPinningGlobal", func(t *testing.T) {
-		in := models.VCPUPinningGlobal{
+		in := domain.VCPUPinningGlobal{
 			Enabled: true,
-			Mappings: []models.VCPUToHostMapping{
+			Mappings: []domain.VCPUToHostMapping{
 				{VCPUID: 0, HostCPUID: 4},
 			},
 		}
 		if err := repo.SaveConfig("vcpu_pinning", in); err != nil {
 			t.Fatal(err)
 		}
-		var out models.VCPUPinningGlobal
+		var out domain.VCPUPinningGlobal
 		if err := repo.GetConfig("vcpu_pinning", &out); err != nil {
 			t.Fatal(err)
 		}
@@ -100,11 +100,11 @@ func TestConfigStore_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("StartStopScript", func(t *testing.T) {
-		in := models.StartStopScript{UseBuiltin: false, StartScript: "echo start", StopScript: "echo stop"}
+		in := domain.StartStopScript{UseBuiltin: false, StartScript: "echo start", StopScript: "echo stop"}
 		if err := repo.SaveConfig("custom_script", in); err != nil {
 			t.Fatal(err)
 		}
-		var out models.StartStopScript
+		var out domain.StartStopScript
 		if err := repo.GetConfig("custom_script", &out); err != nil {
 			t.Fatal(err)
 		}
@@ -114,7 +114,7 @@ func TestConfigStore_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("GetUnsetKeyReturnsZeroValue", func(t *testing.T) {
-		var opts models.CPUOptions
+		var opts domain.CPUOptions
 		if err := repo.GetConfig("nonexistent_key", &opts); err != nil {
 			t.Fatal(err)
 		}
@@ -122,15 +122,15 @@ func TestConfigStore_RoundTrip(t *testing.T) {
 	})
 
 	t.Run("OverwriteExistingKey", func(t *testing.T) {
-		in1 := models.CPUOptions{HideKVM: true}
-		in2 := models.CPUOptions{HVRelaxed: true}
+		in1 := domain.CPUOptions{HideKVM: true}
+		in2 := domain.CPUOptions{HVRelaxed: true}
 		if err := repo.SaveConfig("cpu_options", in1); err != nil {
 			t.Fatal(err)
 		}
 		if err := repo.SaveConfig("cpu_options", in2); err != nil {
 			t.Fatal(err)
 		}
-		var out models.CPUOptions
+		var out domain.CPUOptions
 		if err := repo.GetConfig("cpu_options", &out); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/vm/cpu_options_persistence_test.go
+++ b/internal/vm/cpu_options_persistence_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 func TestGetCPUOptionsDefaults(t *testing.T) {
@@ -20,7 +20,7 @@ func TestGetCPUOptionsDefaults(t *testing.T) {
 		t.Fatalf("NewRepository error: %v", err)
 	}
 
-	var opts models.CPUOptions
+	var opts domain.CPUOptions
 	if err := repo.GetConfig("cpu_options", &opts); err != nil {
 		t.Fatalf("GetConfig error: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestSaveAndLoadCPUOptions(t *testing.T) {
 	}
 
 	// Save CPU options
-	opts := models.CPUOptions{
+	opts := domain.CPUOptions{
 		HideKVM:     true,
 		VendorID:    "AuthenticAMD",
 		HVRelaxed:   true,
@@ -63,7 +63,7 @@ func TestSaveAndLoadCPUOptions(t *testing.T) {
 	}
 
 	// Load CPU options
-	var loaded models.CPUOptions
+	var loaded domain.CPUOptions
 	if err := repo.GetConfig("cpu_options", &loaded); err != nil {
 		t.Fatalf("GetConfig error: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestCPUOptionsRoundTrip(t *testing.T) {
 	repo1, _ := NewRepository(configFile)
 
 	// Save all options set to true
-	opts := models.CPUOptions{
+	opts := domain.CPUOptions{
 		HideKVM:                true,
 		VendorID:               "GenuineIntel",
 		HVFrequency:            true,
@@ -137,7 +137,7 @@ func TestCPUOptionsRoundTrip(t *testing.T) {
 
 	// Fresh repository (simulates app restart)
 	repo2, _ := NewRepository(configFile)
-	var loaded models.CPUOptions
+	var loaded domain.CPUOptions
 	if err := repo2.GetConfig("cpu_options", &loaded); err != nil {
 		t.Fatalf("GetConfig error: %v", err)
 	}
@@ -168,10 +168,10 @@ func TestCPUOptionsCoexistsWithVMs(t *testing.T) {
 	repo, _ := NewRepository(configFile)
 
 	// Save a VM
-	repo.SaveVM(&models.VM{ID: "0", Name: "test-vm"})
+	repo.SaveVM(&domain.VM{ID: "0", Name: "test-vm"})
 
 	// Save CPU options
-	opts := models.CPUOptions{HideKVM: true, HVRelaxed: true}
+	opts := domain.CPUOptions{HideKVM: true, HVRelaxed: true}
 	repo.SaveConfig("cpu_options", opts)
 
 	// Verify both exist
@@ -180,7 +180,7 @@ func TestCPUOptionsCoexistsWithVMs(t *testing.T) {
 		t.Errorf("Expected 1 VM, got %d", len(vms))
 	}
 
-	var loaded models.CPUOptions
+	var loaded domain.CPUOptions
 	repo.GetConfig("cpu_options", &loaded)
 	if !loaded.HideKVM {
 		t.Errorf("CPU options not preserved after saving VM")
@@ -190,7 +190,7 @@ func TestCPUOptionsCoexistsWithVMs(t *testing.T) {
 	}
 
 	// Save another VM and verify CPU options persist
-	repo.SaveVM(&models.VM{ID: "1", Name: "test-vm-2"})
+	repo.SaveVM(&domain.VM{ID: "1", Name: "test-vm-2"})
 
 	vms, _ = repo.ListVMs()
 	if len(vms) != 2 {

--- a/internal/vm/cpu_pinning_test.go
+++ b/internal/vm/cpu_pinning_test.go
@@ -3,7 +3,7 @@ package vm
 import (
 	"testing"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 func TestParseCPUList(t *testing.T) {
@@ -33,7 +33,7 @@ func TestParseCPUListInvalid(t *testing.T) {
 
 func TestComputePinningFromTopology(t *testing.T) {
 	host := testHostTopoSingleDie()
-	topo := models.CPUTopology{Enabled: true, SelectedCPUs: []int{4, 5, 6, 7}}
+	topo := domain.CPUTopology{Enabled: true, SelectedCPUs: []int{4, 5, 6, 7}}
 	pin, err := ComputePinningFromTopology(topo, host)
 	if err != nil {
 		t.Fatalf("ComputePinningFromTopology: %v", err)
@@ -51,7 +51,7 @@ func TestComputePinningFromTopology(t *testing.T) {
 
 func TestComputePinningFromTopologyMixedDies(t *testing.T) {
 	host := testHostTopoTwoDies()
-	topo := models.CPUTopology{Enabled: true, SelectedCPUs: []int{0, 1, 8, 9}}
+	topo := domain.CPUTopology{Enabled: true, SelectedCPUs: []int{0, 1, 8, 9}}
 	pin, err := ComputePinningFromTopology(topo, host)
 	if err != nil {
 		t.Fatalf("ComputePinningFromTopology: %v", err)
@@ -72,13 +72,13 @@ func TestComputePinningFromTopologyMixedDies(t *testing.T) {
 	}
 }
 
-func testHostTopoSingleDie() models.HostCPUTopology {
-	return models.HostCPUTopology{Dies: []models.CPUDie{{ID: 0, CoreDetails: []models.CPUCore{{ID: 2, DieID: 0, Threads: []int{4, 5}}, {ID: 3, DieID: 0, Threads: []int{6, 7}}}}}}
+func testHostTopoSingleDie() domain.HostCPUTopology {
+	return domain.HostCPUTopology{Dies: []domain.CPUDie{{ID: 0, CoreDetails: []domain.CPUCore{{ID: 2, DieID: 0, Threads: []int{4, 5}}, {ID: 3, DieID: 0, Threads: []int{6, 7}}}}}}
 }
 
-func testHostTopoTwoDies() models.HostCPUTopology {
-	return models.HostCPUTopology{Dies: []models.CPUDie{
-		{ID: 0, CoreDetails: []models.CPUCore{{ID: 0, DieID: 0, Threads: []int{0, 1}}}},
-		{ID: 1, CoreDetails: []models.CPUCore{{ID: 4, DieID: 1, Threads: []int{8, 9}}}},
+func testHostTopoTwoDies() domain.HostCPUTopology {
+	return domain.HostCPUTopology{Dies: []domain.CPUDie{
+		{ID: 0, CoreDetails: []domain.CPUCore{{ID: 0, DieID: 0, Threads: []int{0, 1}}}},
+		{ID: 1, CoreDetails: []domain.CPUCore{{ID: 4, DieID: 1, Threads: []int{8, 9}}}},
 	}}
 }

--- a/internal/vm/cpu_scanner.go
+++ b/internal/vm/cpu_scanner.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 const (
@@ -37,14 +37,14 @@ func NewCPUScannerWithPath(sysfsPath string) *CPUScanner {
 }
 
 // ScanTopology detects the host CPU topology from sysfs
-func (s *CPUScanner) ScanTopology() (models.HostCPUTopology, error) {
+func (s *CPUScanner) ScanTopology() (domain.HostCPUTopology, error) {
 	cpuDirs, err := s.findOnlineCPUDirs()
 	if err != nil {
-		return models.HostCPUTopology{}, fmt.Errorf("failed to find CPU directories: %w", err)
+		return domain.HostCPUTopology{}, fmt.Errorf("failed to find CPU directories: %w", err)
 	}
 
 	if len(cpuDirs) == 0 {
-		return models.HostCPUTopology{}, fmt.Errorf("no CPU entries found in %s", s.sysfsPath)
+		return domain.HostCPUTopology{}, fmt.Errorf("no CPU entries found in %s", s.sysfsPath)
 	}
 
 	// Collect per-CPU topology info
@@ -99,13 +99,13 @@ func (s *CPUScanner) ScanTopology() (models.HostCPUTopology, error) {
 	}
 
 	// Group by die
-	dieMap := make(map[int]*models.CPUDie)
+	dieMap := make(map[int]*domain.CPUDie)
 	coreThreads := make(map[string][]int) // key: "dieID:coreID" -> thread IDs
 
 	for _, cpu := range cpus {
 		die, ok := dieMap[cpu.dieID]
 		if !ok {
-			die = &models.CPUDie{
+			die = &domain.CPUDie{
 				ID:           cpu.dieID,
 				Threads:      threadsPerCore,
 				L3CacheKB:    s.readL3CacheKB(cpu.dieID),
@@ -137,7 +137,7 @@ func (s *CPUScanner) ScanTopology() (models.HostCPUTopology, error) {
 					key := fmt.Sprintf("%d:%d", die.ID, cpu.coreID)
 					threads := coreThreads[key]
 					sort.Ints(threads)
-					die.CoreDetails = append(die.CoreDetails, models.CPUCore{
+					die.CoreDetails = append(die.CoreDetails, domain.CPUCore{
 						ID:      cpu.coreID,
 						Threads: threads,
 						DieID:   die.ID,
@@ -153,7 +153,7 @@ func (s *CPUScanner) ScanTopology() (models.HostCPUTopology, error) {
 	}
 
 	// Convert map to sorted slice
-	dies := make([]models.CPUDie, 0, len(dieMap))
+	dies := make([]domain.CPUDie, 0, len(dieMap))
 	var dieIDs []int
 	for id := range dieMap {
 		dieIDs = append(dieIDs, id)
@@ -173,7 +173,7 @@ func (s *CPUScanner) ScanTopology() (models.HostCPUTopology, error) {
 		totalCPUs += len(die.LogicalCPUs)
 	}
 
-	return models.HostCPUTopology{
+	return domain.HostCPUTopology{
 		Dies:           dies,
 		TotalCores:     totalCores,
 		TotalCPUs:      totalCPUs,
@@ -399,7 +399,7 @@ func parseCacheSizeKB(s string) int {
 // CPUIndexToTopology maps a logical CPU index to host topology coordinates.
 // Uses HostCPUTopology to find die-id, core-id, thread-id.
 // Returns error if CPU ID is not found in the topology.
-func CPUIndexToTopology(cpuID int, host models.HostCPUTopology) (dieID, coreID, threadID int, err error) {
+func CPUIndexToTopology(cpuID int, host domain.HostCPUTopology) (dieID, coreID, threadID int, err error) {
 	// Search through all dies and cores for this CPU
 	for _, die := range host.Dies {
 		for _, core := range die.CoreDetails {

--- a/internal/vm/cpu_scanner_test.go
+++ b/internal/vm/cpu_scanner_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // createMockSysfs creates a fake sysfs tree for testing CPU topology detection.
@@ -301,16 +301,16 @@ func TestCPUScannerAsymmetricL3(t *testing.T) {
 
 func TestCPUIndexToTopology(t *testing.T) {
 	// Build a mock host topology matching the mock sysfs created by createMockSysfs
-	hostTopo := models.HostCPUTopology{
+	hostTopo := domain.HostCPUTopology{
 		TotalCores:      8,
 		TotalCPUs:     16,
 		ThreadsPerCore: 2,
-		Dies: []models.CPUDie{
+		Dies: []domain.CPUDie{
 			{
 				ID:     0,
 				Cores:  4,
 				Threads: 2,
-				CoreDetails: []models.CPUCore{
+				CoreDetails: []domain.CPUCore{
 					{ID: 0, DieID: 0, Threads: []int{0, 1}},
 					{ID: 1, DieID: 0, Threads: []int{2, 3}},
 					{ID: 2, DieID: 0, Threads: []int{4, 5}},
@@ -321,7 +321,7 @@ func TestCPUIndexToTopology(t *testing.T) {
 				ID:     1,
 				Cores:  4,
 				Threads: 2,
-				CoreDetails: []models.CPUCore{
+				CoreDetails: []domain.CPUCore{
 					{ID: 0, DieID: 1, Threads: []int{8, 9}},
 					{ID: 1, DieID: 1, Threads: []int{10, 11}},
 					{ID: 2, DieID: 1, Threads: []int{12, 13}},
@@ -376,7 +376,7 @@ func TestCPUIndexToTopology(t *testing.T) {
 }
 
 func TestCPUIndexToTopologyEmpty(t *testing.T) {
-	hostTopo := models.HostCPUTopology{}
+	hostTopo := domain.HostCPUTopology{}
 
 	_, _, _, err := CPUIndexToTopology(0, hostTopo)
 	if err == nil {

--- a/internal/vm/discovery.go
+++ b/internal/vm/discovery.go
@@ -1,25 +1,25 @@
 package vm
 
-import "github.com/glemsom/dkvmmanager/internal/models"
+import "github.com/glemsom/dkvmmanager/internal/domain"
 
 // HostDiscovery provides host hardware scanning capabilities.
 type HostDiscovery interface {
-	ScanPCIDevices() ([]models.PCIDevice, error)
-	ScanUSBDevices() ([]models.USBDevice, error)
-	ScanCPUTopology() (models.HostCPUTopology, error)
+	ScanPCIDevices() ([]domain.PCIDevice, error)
+	ScanUSBDevices() ([]domain.USBDevice, error)
+	ScanCPUTopology() (domain.HostCPUTopology, error)
 }
 
 // DefaultHostDiscovery is the production implementation using system scanners.
 type DefaultHostDiscovery struct{}
 
-func (d *DefaultHostDiscovery) ScanPCIDevices() ([]models.PCIDevice, error) {
+func (d *DefaultHostDiscovery) ScanPCIDevices() ([]domain.PCIDevice, error) {
 	return NewPCIScanner().ScanDevices()
 }
 
-func (d *DefaultHostDiscovery) ScanUSBDevices() ([]models.USBDevice, error) {
+func (d *DefaultHostDiscovery) ScanUSBDevices() ([]domain.USBDevice, error) {
 	return NewUSBScanner().ScanDevices()
 }
 
-func (d *DefaultHostDiscovery) ScanCPUTopology() (models.HostCPUTopology, error) {
+func (d *DefaultHostDiscovery) ScanCPUTopology() (domain.HostCPUTopology, error) {
 	return NewCPUScanner().ScanTopology()
 }

--- a/internal/vm/grub_config.go
+++ b/internal/vm/grub_config.go
@@ -7,12 +7,12 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // BuildVFIOIDs builds the vfio-pci.ids parameter value from PCI passthrough devices.
 // Format: "vendor1:device1,vendor2:device2,..."
-func BuildVFIOIDs(devices []models.PCIPassthroughDevice) string {
+func BuildVFIOIDs(devices []domain.PCIPassthroughDevice) string {
 	if len(devices) == 0 {
 		return ""
 	}

--- a/internal/vm/grub_config_test.go
+++ b/internal/vm/grub_config_test.go
@@ -6,30 +6,30 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 func TestBuildVFIOIDs(t *testing.T) {
 	tests := []struct {
 		name     string
-		devices  []models.PCIPassthroughDevice
+		devices  []domain.PCIPassthroughDevice
 		expected string
 	}{
 		{
 			name:     "empty devices",
-			devices:  []models.PCIPassthroughDevice{},
+			devices:  []domain.PCIPassthroughDevice{},
 			expected: "",
 		},
 		{
 			name: "single device",
-			devices: []models.PCIPassthroughDevice{
+			devices: []domain.PCIPassthroughDevice{
 				{Vendor: "1002", Device: "7550"},
 			},
 			expected: "1002:7550",
 		},
 		{
 			name: "multiple devices",
-			devices: []models.PCIPassthroughDevice{
+			devices: []domain.PCIPassthroughDevice{
 				{Vendor: "1002", Device: "7550"},
 				{Vendor: "1002", Device: "ab40"},
 				{Vendor: "8086", Device: "15d4"},
@@ -560,24 +560,24 @@ menuentry 'DKVM' {
 func TestBuildHostCPUList(t *testing.T) {
 	tests := []struct {
 		name     string
-		mappings []models.VCPUToHostMapping
+		mappings []domain.VCPUToHostMapping
 		expected string
 	}{
 		{
 			name:     "empty mappings",
-			mappings: []models.VCPUToHostMapping{},
+			mappings: []domain.VCPUToHostMapping{},
 			expected: "",
 		},
 		{
 			name: "single mapping",
-			mappings: []models.VCPUToHostMapping{
+			mappings: []domain.VCPUToHostMapping{
 				{VCPUID: 0, HostCPUID: 4},
 			},
 			expected: "4",
 		},
 		{
 			name: "multiple mappings sorted",
-			mappings: []models.VCPUToHostMapping{
+			mappings: []domain.VCPUToHostMapping{
 				{VCPUID: 0, HostCPUID: 6},
 				{VCPUID: 1, HostCPUID: 4},
 				{VCPUID: 2, HostCPUID: 5},
@@ -586,7 +586,7 @@ func TestBuildHostCPUList(t *testing.T) {
 		},
 		{
 			name: "deduplicates same host CPU",
-			mappings: []models.VCPUToHostMapping{
+			mappings: []domain.VCPUToHostMapping{
 				{VCPUID: 0, HostCPUID: 2},
 				{VCPUID: 1, HostCPUID: 2},
 				{VCPUID: 2, HostCPUID: 4},

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/glemsom/dkvmmanager/internal/config"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // Manager handles virtual machine operations
@@ -53,17 +53,17 @@ func (m *Manager) GetConfig() *config.Config {
 }
 
 // ListVMs returns all configured VMs
-func (m *Manager) ListVMs() ([]models.VM, error) {
+func (m *Manager) ListVMs() ([]domain.VM, error) {
 	return m.repository.ListVMs()
 }
 
 // GetVM returns a VM by ID
-func (m *Manager) GetVM(id string) (*models.VM, error) {
+func (m *Manager) GetVM(id string) (*domain.VM, error) {
 	return m.repository.GetVM(id)
 }
 
 // CreateVM creates a new VM
-func (m *Manager) CreateVM(name string) (*models.VM, error) {
+func (m *Manager) CreateVM(name string) (*domain.VM, error) {
 	// Find next available VM ID
 	vmID, err := m.repository.FindNextAvailableID()
 	if err != nil {
@@ -82,7 +82,7 @@ func (m *Manager) CreateVM(name string) (*models.VM, error) {
 	}
 
 	// Create VM config
-	vm := models.VM{
+	vm := domain.VM{
 		ID:        fmt.Sprintf("%d", vmID),
 		Name:      name,
 		CreatedAt: time.Now(),
@@ -98,7 +98,7 @@ func (m *Manager) CreateVM(name string) (*models.VM, error) {
 }
 
 // CreateVMWithMAC creates a new VM with a specific MAC address (for testing)
-func (m *Manager) CreateVMWithMAC(name, mac string) (*models.VM, error) {
+func (m *Manager) CreateVMWithMAC(name, mac string) (*domain.VM, error) {
 	// Find next available VM ID
 	vmID, err := m.repository.FindNextAvailableID()
 	if err != nil {
@@ -117,7 +117,7 @@ func (m *Manager) CreateVMWithMAC(name, mac string) (*models.VM, error) {
 	}
 
 	// Create VM config with specified MAC
-	vm := models.VM{
+	vm := domain.VM{
 		ID:        fmt.Sprintf("%d", vmID),
 		Name:      name,
 		CreatedAt: time.Now(),
@@ -133,7 +133,7 @@ func (m *Manager) CreateVMWithMAC(name, mac string) (*models.VM, error) {
 }
 
 // SaveVM saves a VM configuration
-func (m *Manager) SaveVM(vm *models.VM) error {
+func (m *Manager) SaveVM(vm *domain.VM) error {
 	return m.repository.SaveVM(vm)
 }
 
@@ -167,7 +167,7 @@ func (m *Manager) ApplyVFIOIDsToKernel() error {
 	}
 
 	// Get current PCI passthrough config
-	var pciCfg models.PCIPassthroughConfig
+	var pciCfg domain.PCIPassthroughConfig
 	if err := m.repository.GetConfig("pci_passthrough", &pciCfg); err != nil {
 		if debugMode {
 			log.Printf("[DEBUG] ApplyVFIOIDsToKernel: failed to get PCI config: %v", err)
@@ -237,7 +237,7 @@ func (m *Manager) ApplyCPUParamsToKernel() error {
 	}
 
 	// Get current vCPU pinning config
-	var pinning models.VCPUPinningGlobal
+	var pinning domain.VCPUPinningGlobal
 	if err := m.repository.GetConfig("vcpu_pinning", &pinning); err != nil {
 		if debugMode {
 			log.Printf("[DEBUG] ApplyCPUParamsToKernel: failed to get vCPU pinning config: %v", err)
@@ -372,7 +372,7 @@ func generateMAC() string {
 
 // buildHostCPUList extracts sorted, deduplicated host CPU IDs from pinning mappings
 // and returns them as a comma-separated string (e.g., "0,1,2,3").
-func buildHostCPUList(mappings []models.VCPUToHostMapping) string {
+func buildHostCPUList(mappings []domain.VCPUToHostMapping) string {
 	cpuSet := make(map[int]bool)
 	for _, m := range mappings {
 		cpuSet[m.HostCPUID] = true

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/glemsom/dkvmmanager/internal/config"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 func TestGenerateMAC(t *testing.T) {
@@ -92,7 +92,7 @@ func TestListVMsWithMultipleDisks(t *testing.T) {
 	}
 
 	// Create VM using new API
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:        "0",
 		Name:      "test-vm",
 		HardDisks: []string{"/dev/sda", "/dev/sdb"},
@@ -314,7 +314,7 @@ func TestSaveVMConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:        "7",
 		Name:      "save-test-vm",
 		HardDisks: []string{"/dev/sda", "/dev/sdb"},
@@ -362,7 +362,7 @@ func TestNetworkModePersistence(t *testing.T) {
 	}
 
 	// Save a VM with network_mode set to "bridge"
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:          "0",
 		Name:        "net-test-vm",
 		MAC:         "aa:bb:cc:dd:ee:ff",
@@ -407,7 +407,7 @@ func TestNetworkModePersistenceRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:          "0",
 		Name:        "roundtrip-vm",
 		NetworkMode: "bridge",

--- a/internal/vm/metrics_test.go
+++ b/internal/vm/metrics_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/glemsom/dkvmmanager/internal/config"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // mockQMPClient implements QMPClientInterface for testing.
@@ -67,7 +67,7 @@ func (m *mockQMPClient) Quit() error            { return nil }
 func (m *mockQMPClient) Events() <-chan QMPEvent { return nil }
 
 func TestSnapshotColdSnapshot(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 
@@ -114,7 +114,7 @@ func TestSnapshotColdSnapshot(t *testing.T) {
 }
 
 func TestSnapshotWarmSnapshot(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 
@@ -176,7 +176,7 @@ func TestSnapshotWarmSnapshot(t *testing.T) {
 }
 
 func TestSnapshotNoQMPClient(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 
@@ -195,7 +195,7 @@ func TestSnapshotNoQMPClient(t *testing.T) {
 }
 
 func TestSnapshotQMPError(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 
@@ -214,7 +214,7 @@ func TestSnapshotQMPError(t *testing.T) {
 // client. The fields are populated with raw counters; the per-disk
 // B/s and IOPS math lives in the warm-snapshot test below.
 func TestSnapshotBlockAndBalloonPopulated(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 
@@ -270,7 +270,7 @@ func TestSnapshotBlockAndBalloonPopulated(t *testing.T) {
 // (QueryBalloon returns 0 with no error via graceful degradation) and when
 // query-blockstats returns an empty array.
 func TestSnapshotBlockAndBalloonGracefulNoBalloon(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 
@@ -305,7 +305,7 @@ func TestSnapshotBlockAndBalloonGracefulNoBalloon(t *testing.T) {
 // On the first call (cold), the B/s and IOPS fields are zero. On the second
 // call, they reflect the delta in raw counters divided by the wall-clock delta.
 func TestSnapshotBlockDelta(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 
@@ -444,7 +444,7 @@ func (c *countingBlockClient) QueryBlockStats() ([]QMPBlockDeviceStats, error) {
 // Snapshot() must be gracefully tolerated — Snapshot returns the metrics
 // with BalloonBytes=0 and no error, and other fields are still populated.
 func TestSnapshotBalloonNotActivatedGraceful(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 
@@ -482,7 +482,7 @@ func TestSnapshotBalloonNotActivatedGraceful(t *testing.T) {
 }
 
 func TestPID(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 
@@ -494,7 +494,7 @@ func TestPID(t *testing.T) {
 // S4 acceptance criteria: given a snapshot with PID=0, host fields are 0
 // and the function does not error. /proc is not consulted.
 func TestSnapshotHostFieldsZeroOnNoPID(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 
@@ -550,7 +550,7 @@ func TestSnapshotHostFieldsZeroOnNoPID(t *testing.T) {
 // S4: Snapshot() returns 0/0 with no error when PID is valid but /proc is
 // unreadable (e.g. process exited between PID discovery and read).
 func TestSnapshotHostFieldsZeroOnUnreadableProc(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 
@@ -584,7 +584,7 @@ func TestSnapshotHostFieldsZeroOnUnreadableProc(t *testing.T) {
 
 // S4: Snapshot() populates host fields when PID is valid and /proc readable.
 func TestSnapshotHostFieldsPopulatedOnValidPID(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 
@@ -622,7 +622,7 @@ func TestSnapshotHostFieldsPopulatedOnValidPID(t *testing.T) {
 
 // S4: warm Snapshot() computes host CPU% from deltas.
 func TestSnapshotHostCPUDelta(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 
@@ -685,7 +685,7 @@ func TestSnapshotHostCPUDelta(t *testing.T) {
 // Issue #66: Snapshot() must call readThreadCPUTime exactly once per vCPU
 // per snapshot call, not twice (double /proc read bug).
 func TestSnapshotReadThreadCPUTimeCalledOncePerVCPU(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 
@@ -743,7 +743,7 @@ func TestSnapshotReadThreadCPUTimeCalledOncePerVCPU(t *testing.T) {
 // Issue #66: Snapshot() with no PID (process not started) should not call
 // readThreadCPUTime at all, and should not double-read.
 func TestSnapshotReadThreadCPUTimeNotCalledWhenNoPID(t *testing.T) {
-	vmObj := &models.VM{Name: "test-vm", ID: "1"}
+	vmObj := &domain.VM{Name: "test-vm", ID: "1"}
 	cfg := &config.Config{}
 	runner := NewVMRunner(vmObj, cfg, RunConfig{})
 

--- a/internal/vm/pci_persistence_test.go
+++ b/internal/vm/pci_persistence_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/glemsom/dkvmmanager/internal/config"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // TestPCIPassthroughConfigPersistence tests that PCI passthrough config
@@ -25,7 +25,7 @@ func TestPCIPassthroughConfigPersistence(t *testing.T) {
 	}
 
 	// Initially, config should be empty
-	var loadedCfg models.PCIPassthroughConfig
+	var loadedCfg domain.PCIPassthroughConfig
 	if err := mgr.Repository().GetConfig("pci_passthrough", &loadedCfg); err != nil {
 		t.Fatalf("GetConfig error: %v", err)
 	}
@@ -34,8 +34,8 @@ func TestPCIPassthroughConfigPersistence(t *testing.T) {
 	}
 
 	// Save a config with one device
-	saveCfg := models.PCIPassthroughConfig{
-		Devices: []models.PCIPassthroughDevice{
+	saveCfg := domain.PCIPassthroughConfig{
+		Devices: []domain.PCIPassthroughDevice{
 			{
 				Address:   "0000:01:00.0",
 				ROMPath:   "/roms/gpu.rom",
@@ -96,8 +96,8 @@ func TestPCIPassthroughConfigMultipleDevices(t *testing.T) {
 	}
 
 	// Save config with multiple devices
-	saveCfg := models.PCIPassthroughConfig{
-		Devices: []models.PCIPassthroughDevice{
+	saveCfg := domain.PCIPassthroughConfig{
+		Devices: []domain.PCIPassthroughDevice{
 			{
 				Address:   "0000:01:00.0",
 				Vendor:    "10de",
@@ -120,7 +120,7 @@ func TestPCIPassthroughConfigMultipleDevices(t *testing.T) {
 		t.Fatalf("SaveConfig error: %v", err)
 	}
 
-	var loadedCfg models.PCIPassthroughConfig
+	var loadedCfg domain.PCIPassthroughConfig
 	if err := mgr.Repository().GetConfig("pci_passthrough", &loadedCfg); err != nil {
 		t.Fatalf("GetConfig error: %v", err)
 	}
@@ -161,8 +161,8 @@ func TestPCIPassthroughConfigOverwrite(t *testing.T) {
 	}
 
 	// Save first config
-	cfg1 := models.PCIPassthroughConfig{
-		Devices: []models.PCIPassthroughDevice{
+	cfg1 := domain.PCIPassthroughConfig{
+		Devices: []domain.PCIPassthroughDevice{
 			{Address: "0000:01:00.0", Vendor: "10de", Device: "1b80", Name: "GPU 1", ClassCode: "0300"},
 		},
 	}
@@ -171,8 +171,8 @@ func TestPCIPassthroughConfigOverwrite(t *testing.T) {
 	}
 
 	// Save second config (overwrite)
-	cfg2 := models.PCIPassthroughConfig{
-		Devices: []models.PCIPassthroughDevice{
+	cfg2 := domain.PCIPassthroughConfig{
+		Devices: []domain.PCIPassthroughDevice{
 			{Address: "0000:02:00.0", Vendor: "1002", Device: "67df", Name: "GPU 2", ClassCode: "0300"},
 		},
 	}
@@ -181,7 +181,7 @@ func TestPCIPassthroughConfigOverwrite(t *testing.T) {
 	}
 
 	// Should have the second config, not the first
-	var loadedCfg models.PCIPassthroughConfig
+	var loadedCfg domain.PCIPassthroughConfig
 	if err := mgr.Repository().GetConfig("pci_passthrough", &loadedCfg); err != nil {
 		t.Fatalf("GetConfig error: %v", err)
 	}
@@ -210,8 +210,8 @@ func TestPCIPassthroughConfigEmptySave(t *testing.T) {
 	}
 
 	// First save a config with a device
-	saveCfg := models.PCIPassthroughConfig{
-		Devices: []models.PCIPassthroughDevice{
+	saveCfg := domain.PCIPassthroughConfig{
+		Devices: []domain.PCIPassthroughDevice{
 			{Address: "0000:01:00.0", Vendor: "10de", Device: "1b80", Name: "GPU", ClassCode: "0300"},
 		},
 	}
@@ -220,12 +220,12 @@ func TestPCIPassthroughConfigEmptySave(t *testing.T) {
 	}
 
 	// Now save empty config
-	emptyCfg := models.PCIPassthroughConfig{Devices: []models.PCIPassthroughDevice{}}
+	emptyCfg := domain.PCIPassthroughConfig{Devices: []domain.PCIPassthroughDevice{}}
 	if err := mgr.Repository().SaveConfig("pci_passthrough", emptyCfg); err != nil {
 		t.Fatalf("Empty save error: %v", err)
 	}
 
-	var loadedCfg models.PCIPassthroughConfig
+	var loadedCfg domain.PCIPassthroughConfig
 	if err := mgr.Repository().GetConfig("pci_passthrough", &loadedCfg); err != nil {
 		t.Fatalf("GetConfig error: %v", err)
 	}

--- a/internal/vm/pci_scanner.go
+++ b/internal/vm/pci_scanner.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 const (
@@ -40,7 +40,7 @@ func NewPCIScanner() *PCIScanner {
 }
 
 // ScanDevices scans the host for all PCI devices
-func (s *PCIScanner) ScanDevices() ([]models.PCIDevice, error) {
+func (s *PCIScanner) ScanDevices() ([]domain.PCIDevice, error) {
 	output, err := s.runLspci()
 	if err != nil {
 		return nil, fmt.Errorf("failed to run lspci: %w", err)
@@ -68,8 +68,8 @@ func (s *PCIScanner) runLspci() (string, error) {
 }
 
 // parseLspciOutput parses the output of lspci -nn -D
-func (s *PCIScanner) parseLspciOutput(output string) []models.PCIDevice {
-	var devices []models.PCIDevice
+func (s *PCIScanner) parseLspciOutput(output string) []domain.PCIDevice {
+	var devices []domain.PCIDevice
 
 	lines := strings.Split(strings.TrimSpace(output), "\n")
 	for _, line := range lines {
@@ -96,7 +96,7 @@ func (s *PCIScanner) parseLspciOutput(output string) []models.PCIDevice {
 		// Class 0604 = PCI-to-PCI bridge (PCIe switch ports, root ports, downstream ports)
 		isBridge := classCode == "0604"
 
-		devices = append(devices, models.PCIDevice{
+		devices = append(devices, domain.PCIDevice{
 			Address:    addr,
 			Vendor:     vendor,
 			Device:     device,
@@ -155,7 +155,7 @@ func GetIOMMUGroupDevices(groupNum int) []string {
 
 // ValidatePCIDevices checks that the given devices exist and their IOMMU groups are valid
 // Returns a list of warnings (non-fatal) and errors (fatal)
-func ValidatePCIDevices(devices []models.PCIPassthroughDevice) (warnings []string, errors []string) {
+func ValidatePCIDevices(devices []domain.PCIPassthroughDevice) (warnings []string, errors []string) {
 	scanner := NewPCIScanner()
 	allDevices, err := scanner.ScanDevices()
 	if err != nil {
@@ -164,7 +164,7 @@ func ValidatePCIDevices(devices []models.PCIPassthroughDevice) (warnings []strin
 	}
 
 	// Build lookup
-	deviceMap := make(map[string]models.PCIDevice)
+	deviceMap := make(map[string]domain.PCIDevice)
 	for _, d := range allDevices {
 		deviceMap[d.Address] = d
 	}

--- a/internal/vm/reload_test.go
+++ b/internal/vm/reload_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // TestSaveAndReloadFromFreshRepository tests saving then reading from a new repository
@@ -17,8 +17,8 @@ func TestSaveAndReloadFromFreshRepository(t *testing.T) {
 
 	// First session: create 2 VMs
 	repo1, _ := NewRepository(configFile)
-	repo1.SaveVM(&models.VM{ID: "0", Name: "vm-zero", HardDisks: []string{"/dev/sda"}, MAC: "aa:bb:cc:dd:ee:ff", VNCListen: "0.0.0.0:0"})
-	repo1.SaveVM(&models.VM{ID: "1", Name: "vm-one", HardDisks: []string{"/dev/sdb"}, MAC: "11:22:33:44:55:66", VNCListen: "0.0.0.0:1"})
+	repo1.SaveVM(&domain.VM{ID: "0", Name: "vm-zero", HardDisks: []string{"/dev/sda"}, MAC: "aa:bb:cc:dd:ee:ff", VNCListen: "0.0.0.0:0"})
+	repo1.SaveVM(&domain.VM{ID: "1", Name: "vm-one", HardDisks: []string{"/dev/sdb"}, MAC: "11:22:33:44:55:66", VNCListen: "0.0.0.0:1"})
 
 	vms, _ := repo1.ListVMs()
 	if len(vms) != 2 {
@@ -33,7 +33,7 @@ func TestSaveAndReloadFromFreshRepository(t *testing.T) {
 	}
 
 	// Edit VM 0 in session 2
-	repo2.SaveVM(&models.VM{ID: "0", Name: "vm-zero-edited", HardDisks: []string{"/dev/sdc"}, MAC: "aa:bb:cc:dd:ee:ff", VNCListen: "0.0.0.0:0"})
+	repo2.SaveVM(&domain.VM{ID: "0", Name: "vm-zero-edited", HardDisks: []string{"/dev/sdc"}, MAC: "aa:bb:cc:dd:ee:ff", VNCListen: "0.0.0.0:0"})
 
 	vms, _ = repo2.ListVMs()
 	if len(vms) != 2 {
@@ -61,12 +61,12 @@ func TestMultipleSequentialSaves(t *testing.T) {
 	repo, _ := NewRepository(configFile)
 
 	// Create 2 VMs
-	repo.SaveVM(&models.VM{ID: "0", Name: "vm-0"})
-	repo.SaveVM(&models.VM{ID: "1", Name: "vm-1"})
+	repo.SaveVM(&domain.VM{ID: "0", Name: "vm-0"})
+	repo.SaveVM(&domain.VM{ID: "1", Name: "vm-1"})
 
 	// Edit VM 0 ten times rapidly
 	for i := 0; i < 10; i++ {
-		repo.SaveVM(&models.VM{ID: "0", Name: "vm-0-edited"})
+		repo.SaveVM(&domain.VM{ID: "0", Name: "vm-0-edited"})
 		vms, err := repo.ListVMs()
 		if err != nil {
 			t.Fatalf("ListVMs error on iteration %d: %v", i, err)
@@ -133,7 +133,7 @@ func TestRealYAMLFormat(t *testing.T) {
 	}
 
 	// Edit VM 0
-	var vm0 *models.VM
+	var vm0 *domain.VM
 	for i := range vms {
 		if vms[i].ID == "0" {
 			vm0 = &vms[i]

--- a/internal/vm/repository.go
+++ b/internal/vm/repository.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/viper"
 )
@@ -56,8 +56,8 @@ func (r *Repository) save() error {
 // === VM Persistence ===
 
 // ListVMs returns all configured VMs
-func (r *Repository) ListVMs() ([]models.VM, error) {
-	var vms []models.VM
+func (r *Repository) ListVMs() ([]domain.VM, error) {
+	var vms []domain.VM
 
 	// Get all VMs from the config
 	vmsMap := r.vip.GetStringMap("vms")
@@ -79,7 +79,7 @@ func (r *Repository) ListVMs() ([]models.VM, error) {
 }
 
 // GetVM returns a VM by ID
-func (r *Repository) GetVM(id string) (*models.VM, error) {
+func (r *Repository) GetVM(id string) (*domain.VM, error) {
 	vmKey := fmt.Sprintf("vms.%s", id)
 	if !r.vip.IsSet(vmKey) {
 		return nil, fmt.Errorf("VM not found: %s", id)
@@ -92,7 +92,7 @@ func (r *Repository) GetVM(id string) (*models.VM, error) {
 }
 
 // SaveVM saves a VM to the config
-func (r *Repository) SaveVM(vm *models.VM) error {
+func (r *Repository) SaveVM(vm *domain.VM) error {
 	if vm.ID == "" {
 		return fmt.Errorf("VM ID is required")
 	}
@@ -210,8 +210,8 @@ func (r *Repository) SaveConfig(key string, src interface{}) error {
 // === Helpers ===
 
 // unmarshalVM converts a map to a VM struct
-func (r *Repository) unmarshalVM(id string, data map[string]interface{}) models.VM {
-	vm := models.VM{
+func (r *Repository) unmarshalVM(id string, data map[string]interface{}) domain.VM {
+	vm := domain.VM{
 		ID:   id,
 		Name: getString(data, "name"),
 	}

--- a/internal/vm/repository_pinning_test.go
+++ b/internal/vm/repository_pinning_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/glemsom/dkvmmanager/internal/config"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 func TestRepositoryVCPUPinningPersistence(t *testing.T) {
@@ -13,11 +13,11 @@ func TestRepositoryVCPUPinningPersistence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository: %v", err)
 	}
-	in := models.VCPUPinningGlobal{Enabled: true, Mappings: []models.VCPUToHostMapping{{VCPUID: 0, HostCPUID: 4}, {VCPUID: 1, HostCPUID: 5}}}
+	in := domain.VCPUPinningGlobal{Enabled: true, Mappings: []domain.VCPUToHostMapping{{VCPUID: 0, HostCPUID: 4}, {VCPUID: 1, HostCPUID: 5}}}
 	if err := repo.SaveConfig("vcpu_pinning", in); err != nil {
 		t.Fatalf("SaveConfig: %v", err)
 	}
-	var out models.VCPUPinningGlobal
+	var out domain.VCPUPinningGlobal
 	if err := repo.GetConfig("vcpu_pinning", &out); err != nil {
 		t.Fatalf("GetConfig: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestRepositoryVCPUPinningPersistence(t *testing.T) {
 	if err := mgr.Repository().SaveConfig("vcpu_pinning", in); err != nil {
 		t.Fatalf("manager SaveConfig: %v", err)
 	}
-	var mgrOut models.VCPUPinningGlobal
+	var mgrOut domain.VCPUPinningGlobal
 	if err := mgr.Repository().GetConfig("vcpu_pinning", &mgrOut); err != nil {
 		t.Fatalf("manager GetConfig: %v", err)
 	}

--- a/internal/vm/repository_topology_test.go
+++ b/internal/vm/repository_topology_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // mockRepositoryForTopology creates a repository with a temporary config file
@@ -44,7 +44,7 @@ func TestGetCPUTopology(t *testing.T) {
 		"use_host_topology": true,
 	})
 
-	var topo models.CPUTopology
+	var topo domain.CPUTopology
 	if err := repo.GetConfig("cpu_topology", &topo); err != nil {
 		t.Fatalf("GetConfig error: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestSaveCPUTopology(t *testing.T) {
 	repo, cleanup := mockRepositoryForTopology(t)
 	defer cleanup()
 
-	topo := models.CPUTopology{
+	topo := domain.CPUTopology{
 		Enabled:         true,
 		SelectedCPUs:    []int{0, 1, 2, 3},
 		UseHostTopology: true,
@@ -82,7 +82,7 @@ func TestSaveCPUTopology(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var loaded models.CPUTopology
+	var loaded domain.CPUTopology
 	if err := repo.GetConfig("cpu_topology", &loaded); err != nil {
 		t.Fatalf("GetConfig error after reload: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestSaveCPUTopologyUseHostTopologyFalse(t *testing.T) {
 	repo, cleanup := mockRepositoryForTopology(t)
 	defer cleanup()
 
-	topo := models.CPUTopology{
+	topo := domain.CPUTopology{
 		Enabled:         true,
 		SelectedCPUs:    []int{0, 2, 4, 6},
 		UseHostTopology: false,
@@ -115,7 +115,7 @@ func TestSaveCPUTopologyUseHostTopologyFalse(t *testing.T) {
 		t.Fatalf("SaveConfig error: %v", err)
 	}
 
-	var loaded models.CPUTopology
+	var loaded domain.CPUTopology
 	if err := repo.GetConfig("cpu_topology", &loaded); err != nil {
 		t.Fatalf("GetConfig error: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestSaveCPUTopologyRoundTripMultiple(t *testing.T) {
 	defer cleanup()
 
 	// Test multiple round-trips
-	testCases := []models.CPUTopology{
+	testCases := []domain.CPUTopology{
 		{Enabled: true, SelectedCPUs: []int{0}, UseHostTopology: true},
 		{Enabled: false, SelectedCPUs: []int{1, 2, 3, 4}, UseHostTopology: false},
 		{Enabled: true, SelectedCPUs: []int{0, 1, 2, 3, 4, 5, 6, 7}, UseHostTopology: true},
@@ -141,7 +141,7 @@ func TestSaveCPUTopologyRoundTripMultiple(t *testing.T) {
 			t.Fatalf("SaveConfig test case %d error: %v", i, err)
 		}
 
-		var loaded models.CPUTopology
+		var loaded domain.CPUTopology
 		if err := repo.GetConfig("cpu_topology", &loaded); err != nil {
 			t.Fatalf("GetConfig test case %d error: %v", i, err)
 		}

--- a/internal/vm/run_config.go
+++ b/internal/vm/run_config.go
@@ -1,19 +1,19 @@
 package vm
 
 import (
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // RunConfig aggregates all optional configuration for VMRunner into a single value.
 // A zero-valued RunConfig is safe to use (no panics, all fields at zero value).
 type RunConfig struct {
-	PCIPassthroughConfig models.PCIPassthroughConfig
-	USBPassthroughConfig models.USBPassthroughConfig
-	CPUOptions           models.CPUOptions
-	CPUTopology          models.CPUTopology
-	HostCPUTopology      models.HostCPUTopology
-	VCPUPinning          models.VCPUPinningGlobal
-	StartStopScript      models.StartStopScript
+	PCIPassthroughConfig domain.PCIPassthroughConfig
+	USBPassthroughConfig domain.USBPassthroughConfig
+	CPUOptions           domain.CPUOptions
+	CPUTopology          domain.CPUTopology
+	HostCPUTopology      domain.HostCPUTopology
+	VCPUPinning          domain.VCPUPinningGlobal
+	StartStopScript      domain.StartStopScript
 	DryRun               bool
 }
 

--- a/internal/vm/run_config_test.go
+++ b/internal/vm/run_config_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // TestRunConfigZeroValue verifies that a zero-valued RunConfig is safe to use
@@ -51,25 +51,25 @@ func TestRunConfigStructFields(t *testing.T) {
 	rc := RunConfig{}
 
 	// 1. PCIPassthroughConfig
-	_ = models.PCIPassthroughConfig(rc.PCIPassthroughConfig)
+	_ = domain.PCIPassthroughConfig(rc.PCIPassthroughConfig)
 
 	// 2. USBPassthroughConfig
-	_ = models.USBPassthroughConfig(rc.USBPassthroughConfig)
+	_ = domain.USBPassthroughConfig(rc.USBPassthroughConfig)
 
 	// 3. CPUOptions
-	_ = models.CPUOptions(rc.CPUOptions)
+	_ = domain.CPUOptions(rc.CPUOptions)
 
 	// 4. CPUTopology
-	_ = models.CPUTopology(rc.CPUTopology)
+	_ = domain.CPUTopology(rc.CPUTopology)
 
 	// 5. HostCPUTopology
-	_ = models.HostCPUTopology(rc.HostCPUTopology)
+	_ = domain.HostCPUTopology(rc.HostCPUTopology)
 
 	// 6. VCPUPinning
-	_ = models.VCPUPinningGlobal(rc.VCPUPinning)
+	_ = domain.VCPUPinningGlobal(rc.VCPUPinning)
 
 	// 7. StartStopScript
-	_ = models.StartStopScript(rc.StartStopScript)
+	_ = domain.StartStopScript(rc.StartStopScript)
 
 	// 8. DryRun
 	_ = bool(rc.DryRun)
@@ -120,8 +120,8 @@ func TestLoadRunConfigFromRepoPopulated(t *testing.T) {
 	}
 
 	// Save configs using the same keys that LoadRunConfigFromRepo will read
-	pciCfg := models.PCIPassthroughConfig{
-		Devices: []models.PCIPassthroughDevice{
+	pciCfg := domain.PCIPassthroughConfig{
+		Devices: []domain.PCIPassthroughDevice{
 			{Address: "0000:01:00.0", Vendor: "10de", Device: "1b80", Name: "GPU"},
 		},
 	}
@@ -129,8 +129,8 @@ func TestLoadRunConfigFromRepoPopulated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	usbCfg := models.USBPassthroughConfig{
-		Devices: []models.USBPassthroughDevice{
+	usbCfg := domain.USBPassthroughConfig{
+		Devices: []domain.USBPassthroughDevice{
 			{Vendor: "046d", Product: "c52b", Name: "Unifying Receiver"},
 		},
 	}
@@ -138,19 +138,19 @@ func TestLoadRunConfigFromRepoPopulated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cpuOpts := models.CPUOptions{HideKVM: true, HVRelaxed: true, VendorID: "GenuineIntel"}
+	cpuOpts := domain.CPUOptions{HideKVM: true, HVRelaxed: true, VendorID: "GenuineIntel"}
 	if err := repo.SaveConfig("cpu_options", cpuOpts); err != nil {
 		t.Fatal(err)
 	}
 
-	cpuTopo := models.CPUTopology{Enabled: true, SelectedCPUs: []int{0, 1, 2, 3}}
+	cpuTopo := domain.CPUTopology{Enabled: true, SelectedCPUs: []int{0, 1, 2, 3}}
 	if err := repo.SaveConfig("cpu_topology", cpuTopo); err != nil {
 		t.Fatal(err)
 	}
 
-	vcpuPin := models.VCPUPinningGlobal{
+	vcpuPin := domain.VCPUPinningGlobal{
 		Enabled: true,
-		Mappings: []models.VCPUToHostMapping{
+		Mappings: []domain.VCPUToHostMapping{
 			{VCPUID: 0, HostCPUID: 4},
 		},
 	}
@@ -158,7 +158,7 @@ func TestLoadRunConfigFromRepoPopulated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	scriptCfg := models.StartStopScript{UseBuiltin: false, StartScript: "echo start", StopScript: "echo stop"}
+	scriptCfg := domain.StartStopScript{UseBuiltin: false, StartScript: "echo start", StopScript: "echo stop"}
 	if err := repo.SaveConfig("custom_script", scriptCfg); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/vm/script_generator.go
+++ b/internal/vm/script_generator.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // GenerateBuiltinScript generates a builtin start script for PCI passthrough.
 // The script iterates over configured PCI devices and binds the vfio-pci driver.
-func GenerateBuiltinScript(devices []models.PCIPassthroughDevice) (string, error) {
+func GenerateBuiltinScript(devices []domain.PCIPassthroughDevice) (string, error) {
 	if len(devices) == 0 {
 		return "# No PCI devices configured", nil
 	}

--- a/internal/vm/script_generator_test.go
+++ b/internal/vm/script_generator_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // TestGenerateBuiltinScriptEmpty tests script generation with no devices
@@ -20,7 +20,7 @@ func TestGenerateBuiltinScriptEmpty(t *testing.T) {
 
 // TestGenerateBuiltinScriptSingleDevice tests script generation with one device
 func TestGenerateBuiltinScriptSingleDevice(t *testing.T) {
-	devices := []models.PCIPassthroughDevice{
+	devices := []domain.PCIPassthroughDevice{
 		{Address: "0000:01:00.0", Name: "NVIDIA GPU"},
 	}
 
@@ -47,7 +47,7 @@ func TestGenerateBuiltinScriptSingleDevice(t *testing.T) {
 
 // TestGenerateBuiltinScriptWithROM tests script generation with ROM path
 func TestGenerateBuiltinScriptWithROM(t *testing.T) {
-	devices := []models.PCIPassthroughDevice{
+	devices := []domain.PCIPassthroughDevice{
 		{Address: "0000:01:00.0", Name: "NVIDIA GPU", ROMPath: "/roms/gpu.rom"},
 	}
 
@@ -69,7 +69,7 @@ func TestGenerateBuiltinScriptWithROM(t *testing.T) {
 
 // TestGenerateBuiltinScriptMultipleDevices tests script generation with multiple devices
 func TestGenerateBuiltinScriptMultipleDevices(t *testing.T) {
-	devices := []models.PCIPassthroughDevice{
+	devices := []domain.PCIPassthroughDevice{
 		{Address: "0000:01:00.0", Name: "NVIDIA GPU"},
 		{Address: "0000:02:00.0", Name: "USB Controller"},
 	}
@@ -110,7 +110,7 @@ func TestGenerateBuiltinStopScript(t *testing.T) {
 
 // TestGenerateBuiltinScriptUnbind tests that script uses driver_override
 func TestGenerateBuiltinScriptUnbind(t *testing.T) {
-	devices := []models.PCIPassthroughDevice{
+	devices := []domain.PCIPassthroughDevice{
 		{Address: "0000:01:00.0", Name: "NVIDIA GPU"},
 	}
 

--- a/internal/vm/usb_persistence_test.go
+++ b/internal/vm/usb_persistence_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/glemsom/dkvmmanager/internal/config"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // TestUSBPassthroughConfigPersistence tests that USB passthrough config
@@ -25,7 +25,7 @@ func TestUSBPassthroughConfigPersistence(t *testing.T) {
 	}
 
 	// Initially, config should be empty
-	var loadedCfg models.USBPassthroughConfig
+	var loadedCfg domain.USBPassthroughConfig
 	if err := mgr.Repository().GetConfig("usb_passthrough", &loadedCfg); err != nil {
 		t.Fatalf("GetConfig error: %v", err)
 	}
@@ -34,8 +34,8 @@ func TestUSBPassthroughConfigPersistence(t *testing.T) {
 	}
 
 	// Save a config with one device
-	saveCfg := models.USBPassthroughConfig{
-		Devices: []models.USBPassthroughDevice{
+	saveCfg := domain.USBPassthroughConfig{
+		Devices: []domain.USBPassthroughDevice{
 			{
 				Vendor:  "046d",
 				Product: "c52b",
@@ -87,8 +87,8 @@ func TestUSBPassthroughConfigMultipleDevices(t *testing.T) {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
 
-	saveCfg := models.USBPassthroughConfig{
-		Devices: []models.USBPassthroughDevice{
+	saveCfg := domain.USBPassthroughConfig{
+		Devices: []domain.USBPassthroughDevice{
 			{
 				Vendor:  "046d",
 				Product: "c52b",
@@ -108,7 +108,7 @@ func TestUSBPassthroughConfigMultipleDevices(t *testing.T) {
 		t.Fatalf("SaveConfig error: %v", err)
 	}
 
-	var loadedCfg models.USBPassthroughConfig
+	var loadedCfg domain.USBPassthroughConfig
 	if err := mgr.Repository().GetConfig("usb_passthrough", &loadedCfg); err != nil {
 		t.Fatalf("GetConfig error: %v", err)
 	}
@@ -141,8 +141,8 @@ func TestUSBPassthroughConfigOverwrite(t *testing.T) {
 	}
 
 	// Save initial config
-	saveCfg := models.USBPassthroughConfig{
-		Devices: []models.USBPassthroughDevice{
+	saveCfg := domain.USBPassthroughConfig{
+		Devices: []domain.USBPassthroughDevice{
 			{Vendor: "046d", Product: "c52b", Name: "Logitech", BusID: "1-1"},
 		},
 	}
@@ -151,8 +151,8 @@ func TestUSBPassthroughConfigOverwrite(t *testing.T) {
 	}
 
 	// Overwrite with different config
-	newCfg := models.USBPassthroughConfig{
-		Devices: []models.USBPassthroughDevice{
+	newCfg := domain.USBPassthroughConfig{
+		Devices: []domain.USBPassthroughDevice{
 			{Vendor: "045e", Product: "028e", Name: "Xbox Controller", BusID: "3-2"},
 		},
 	}
@@ -160,7 +160,7 @@ func TestUSBPassthroughConfigOverwrite(t *testing.T) {
 		t.Fatalf("SaveConfig error: %v", err)
 	}
 
-	var loadedCfg models.USBPassthroughConfig
+	var loadedCfg domain.USBPassthroughConfig
 	if err := mgr.Repository().GetConfig("usb_passthrough", &loadedCfg); err != nil {
 		t.Fatalf("GetConfig error: %v", err)
 	}

--- a/internal/vm/usb_scanner.go
+++ b/internal/vm/usb_scanner.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 const (
@@ -36,7 +36,7 @@ func NewUSBScanner() *USBScanner {
 }
 
 // ScanDevices scans the host for all USB devices
-func (s *USBScanner) ScanDevices() ([]models.USBDevice, error) {
+func (s *USBScanner) ScanDevices() ([]domain.USBDevice, error) {
 	output, err := s.runLsusb()
 	if err != nil {
 		return nil, fmt.Errorf("failed to run lsusb: %w", err)
@@ -63,8 +63,8 @@ func (s *USBScanner) runLsusb() (string, error) {
 }
 
 // parseLsusbOutput parses the output of lsusb
-func (s *USBScanner) parseLsusbOutput(output string) []models.USBDevice {
-	var devices []models.USBDevice
+func (s *USBScanner) parseLsusbOutput(output string) []domain.USBDevice {
+	var devices []domain.USBDevice
 
 	lines := strings.Split(strings.TrimSpace(output), "\n")
 	for _, line := range lines {
@@ -82,7 +82,7 @@ func (s *USBScanner) parseLsusbOutput(output string) []models.USBDevice {
 		product := strings.ToLower(matches[4])
 		name := strings.TrimSpace(matches[5])
 
-		devices = append(devices, models.USBDevice{
+		devices = append(devices, domain.USBDevice{
 			Vendor:  vendor,
 			Product: product,
 			Name:    name,
@@ -128,7 +128,7 @@ func (s *USBScanner) findBusDeviceID(vendor, product string) string {
 
 // ValidateUSBDevices checks that the given devices exist on the host.
 // Returns a list of warnings (non-fatal) and errors (fatal).
-func ValidateUSBDevices(devices []models.USBPassthroughDevice) (warnings []string, errors []string) {
+func ValidateUSBDevices(devices []domain.USBPassthroughDevice) (warnings []string, errors []string) {
 	// If no devices to validate, return early
 	if len(devices) == 0 {
 		return

--- a/internal/vm/vcpu_pinning_compute.go
+++ b/internal/vm/vcpu_pinning_compute.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // ComputePinningFromTopology derives 1:1 host CPU mappings from selected topology.
 // The mapping order is topology-aware: die -> core -> thread.
-func ComputePinningFromTopology(topo models.CPUTopology, host models.HostCPUTopology) (models.VCPUPinningGlobal, error) {
-	result := models.VCPUPinningGlobal{Enabled: false, Mappings: nil}
+func ComputePinningFromTopology(topo domain.CPUTopology, host domain.HostCPUTopology) (domain.VCPUPinningGlobal, error) {
+	result := domain.VCPUPinningGlobal{Enabled: false, Mappings: nil}
 	if !topo.Enabled || len(topo.SelectedCPUs) == 0 {
 		return result, nil
 	}
@@ -51,9 +51,9 @@ func ComputePinningFromTopology(topo models.CPUTopology, host models.HostCPUTopo
 		return threads[i].thread < threads[j].thread
 	})
 
-	mappings := make([]models.VCPUToHostMapping, 0, len(threads))
+	mappings := make([]domain.VCPUToHostMapping, 0, len(threads))
 	for i, th := range threads {
-		mappings = append(mappings, models.VCPUToHostMapping{VCPUID: i, HostCPUID: th.hostCPU})
+		mappings = append(mappings, domain.VCPUToHostMapping{VCPUID: i, HostCPUID: th.hostCPU})
 	}
 
 	result.Mappings = mappings

--- a/internal/vm/vcpu_topology_mapper.go
+++ b/internal/vm/vcpu_topology_mapper.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // vCPUDevice represents a single vCPU device declaration for QEMU.
@@ -31,7 +31,7 @@ type vCPUDevice struct {
 //  6. Returns -device declarations for all remaining CPUs (skipping the first)
 func GenerateAsymmetricCPUDevices(
 	selectedCPUs []int,
-	hostTopo models.HostCPUTopology,
+	hostTopo domain.HostCPUTopology,
 ) (deviceArgs []string, firstAPICID int, err error) {
 	if len(selectedCPUs) == 0 {
 		return nil, 0, fmt.Errorf("no CPUs selected for asymmetric topology")

--- a/internal/vm/vcpu_topology_mapper_test.go
+++ b/internal/vm/vcpu_topology_mapper_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // --- computeAPICID tests ---
@@ -64,17 +64,17 @@ func TestComputeAPICID(t *testing.T) {
 
 func TestGenerateAsymmetricCPUDevices_Symmetric(t *testing.T) {
 	// All cores on all dies selected — symmetric case
-	hostTopo := models.HostCPUTopology{
+	hostTopo := domain.HostCPUTopology{
 		TotalCores:     8,
 		TotalCPUs:      16,
 		ThreadsPerCore: 2,
-		Dies: []models.CPUDie{
+		Dies: []domain.CPUDie{
 			{
 				ID:          0,
 				Cores:       4,
 				Threads:     2,
 				LogicalCPUs: []int{0, 1, 2, 3, 4, 5, 6, 7},
-				CoreDetails: []models.CPUCore{
+				CoreDetails: []domain.CPUCore{
 					{ID: 0, DieID: 0, Threads: []int{0, 1}},
 					{ID: 1, DieID: 0, Threads: []int{2, 3}},
 					{ID: 2, DieID: 0, Threads: []int{4, 5}},
@@ -86,7 +86,7 @@ func TestGenerateAsymmetricCPUDevices_Symmetric(t *testing.T) {
 				Cores:       4,
 				Threads:     2,
 				LogicalCPUs: []int{8, 9, 10, 11, 12, 13, 14, 15},
-				CoreDetails: []models.CPUCore{
+				CoreDetails: []domain.CPUCore{
 					{ID: 0, DieID: 1, Threads: []int{8, 9}},
 					{ID: 1, DieID: 1, Threads: []int{10, 11}},
 					{ID: 2, DieID: 1, Threads: []int{12, 13}},
@@ -130,17 +130,17 @@ func TestGenerateAsymmetricCPUDevices_Symmetric(t *testing.T) {
 func TestGenerateAsymmetricCPUDevices_PartialDie(t *testing.T) {
 	// Asymmetric: all cores on die 0, cores 10-15 on die 1 (cores 8-9 reserved)
 	// This matches the user's scenario in the implementation plan.
-	hostTopo := models.HostCPUTopology{
+	hostTopo := domain.HostCPUTopology{
 		TotalCores:     16,
 		TotalCPUs:      32,
 		ThreadsPerCore: 2,
-		Dies: []models.CPUDie{
+		Dies: []domain.CPUDie{
 			{
 				ID:          0,
 				Cores:       8,
 				Threads:     2,
 				LogicalCPUs: []int{0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23},
-				CoreDetails: []models.CPUCore{
+				CoreDetails: []domain.CPUCore{
 					{ID: 0, DieID: 0, Threads: []int{0, 16}},
 					{ID: 1, DieID: 0, Threads: []int{1, 17}},
 					{ID: 2, DieID: 0, Threads: []int{2, 18}},
@@ -156,7 +156,7 @@ func TestGenerateAsymmetricCPUDevices_PartialDie(t *testing.T) {
 				Cores:       8,
 				Threads:     2,
 				LogicalCPUs: []int{8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31},
-				CoreDetails: []models.CPUCore{
+				CoreDetails: []domain.CPUCore{
 					{ID: 8, DieID: 1, Threads: []int{8, 24}},
 					{ID: 9, DieID: 1, Threads: []int{9, 25}},
 					{ID: 10, DieID: 1, Threads: []int{10, 26}},
@@ -230,17 +230,17 @@ func TestGenerateAsymmetricCPUDevices_PartialDie(t *testing.T) {
 
 func TestGenerateAsymmetricCPUDevices_SingleDie(t *testing.T) {
 	// Only one die with partial core selection
-	hostTopo := models.HostCPUTopology{
+	hostTopo := domain.HostCPUTopology{
 		TotalCores:     4,
 		TotalCPUs:      8,
 		ThreadsPerCore: 2,
-		Dies: []models.CPUDie{
+		Dies: []domain.CPUDie{
 			{
 				ID:          0,
 				Cores:       4,
 				Threads:     2,
 				LogicalCPUs: []int{0, 1, 2, 3, 4, 5, 6, 7},
-				CoreDetails: []models.CPUCore{
+				CoreDetails: []domain.CPUCore{
 					{ID: 0, DieID: 0, Threads: []int{0, 1}},
 					{ID: 1, DieID: 0, Threads: []int{2, 3}},
 					{ID: 2, DieID: 0, Threads: []int{4, 5}},
@@ -276,17 +276,17 @@ func TestGenerateAsymmetricCPUDevices_SingleDie(t *testing.T) {
 
 func TestGenerateAsymmetricCPUDevices_NoDie0(t *testing.T) {
 	// User selects no CPUs on die 0 — should return an error
-	hostTopo := models.HostCPUTopology{
+	hostTopo := domain.HostCPUTopology{
 		TotalCores:     8,
 		TotalCPUs:      16,
 		ThreadsPerCore: 2,
-		Dies: []models.CPUDie{
+		Dies: []domain.CPUDie{
 			{
 				ID:          0,
 				Cores:       4,
 				Threads:     2,
 				LogicalCPUs: []int{0, 1, 2, 3, 4, 5, 6, 7},
-				CoreDetails: []models.CPUCore{
+				CoreDetails: []domain.CPUCore{
 					{ID: 0, DieID: 0, Threads: []int{0, 1}},
 					{ID: 1, DieID: 0, Threads: []int{2, 3}},
 					{ID: 2, DieID: 0, Threads: []int{4, 5}},
@@ -298,7 +298,7 @@ func TestGenerateAsymmetricCPUDevices_NoDie0(t *testing.T) {
 				Cores:       4,
 				Threads:     2,
 				LogicalCPUs: []int{8, 9, 10, 11, 12, 13, 14, 15},
-				CoreDetails: []models.CPUCore{
+				CoreDetails: []domain.CPUCore{
 					{ID: 0, DieID: 1, Threads: []int{8, 9}},
 					{ID: 1, DieID: 1, Threads: []int{10, 11}},
 					{ID: 2, DieID: 1, Threads: []int{12, 13}},
@@ -321,17 +321,17 @@ func TestGenerateAsymmetricCPUDevices_NoDie0(t *testing.T) {
 }
 
 func TestGenerateAsymmetricCPUDevices_Empty(t *testing.T) {
-	hostTopo := models.HostCPUTopology{
+	hostTopo := domain.HostCPUTopology{
 		TotalCores:     4,
 		TotalCPUs:      8,
 		ThreadsPerCore: 2,
-		Dies: []models.CPUDie{
+		Dies: []domain.CPUDie{
 			{
 				ID:          0,
 				Cores:       4,
 				Threads:     2,
 				LogicalCPUs: []int{0, 1, 2, 3, 4, 5, 6, 7},
-				CoreDetails: []models.CPUCore{
+				CoreDetails: []domain.CPUCore{
 					{ID: 0, DieID: 0, Threads: []int{0, 1}},
 					{ID: 1, DieID: 0, Threads: []int{2, 3}},
 					{ID: 2, DieID: 0, Threads: []int{4, 5}},
@@ -351,17 +351,17 @@ func TestGenerateAsymmetricCPUDevices_Empty(t *testing.T) {
 }
 
 func TestGenerateAsymmetricCPUDevices_InvalidCPU(t *testing.T) {
-	hostTopo := models.HostCPUTopology{
+	hostTopo := domain.HostCPUTopology{
 		TotalCores:     4,
 		TotalCPUs:      8,
 		ThreadsPerCore: 2,
-		Dies: []models.CPUDie{
+		Dies: []domain.CPUDie{
 			{
 				ID:          0,
 				Cores:       4,
 				Threads:     2,
 				LogicalCPUs: []int{0, 1, 2, 3, 4, 5, 6, 7},
-				CoreDetails: []models.CPUCore{
+				CoreDetails: []domain.CPUCore{
 					{ID: 0, DieID: 0, Threads: []int{0, 1}},
 					{ID: 1, DieID: 0, Threads: []int{2, 3}},
 				},

--- a/internal/vm/vm_runner.go
+++ b/internal/vm/vm_runner.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/glemsom/dkvmmanager/internal/config"
 	"github.com/glemsom/dkvmmanager/internal/hugepages"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // Package-level debug mode flag for the vm package
@@ -46,7 +46,7 @@ func SetDryRunMode(enabled bool) {
 
 // VMRunner manages the lifecycle of a running QEMU virtual machine
 type VMRunner struct {
-	vm         *models.VM
+	vm         *domain.VM
 	cfg        *config.Config
 	runCfg     RunConfig
 	cmd        *exec.Cmd
@@ -92,7 +92,7 @@ type VMRunner struct {
 // NewVMRunner creates a new VM runner for the given VM with the provided RunConfig.
 // runCfg aggregates all optional configuration (PCI/USB passthrough, CPU options,
 // topology, pinning, scripts, dry-run). A zero-valued RunConfig is safe to use.
-func NewVMRunner(vm *models.VM, cfg *config.Config, runCfg RunConfig) *VMRunner {
+func NewVMRunner(vm *domain.VM, cfg *config.Config, runCfg RunConfig) *VMRunner {
 	r := &VMRunner{
 		vm:          vm,
 		cfg:         cfg,
@@ -346,7 +346,7 @@ func (r *VMRunner) QMPClient() QMPClientInterface {
 }
 
 // VM returns the VM model
-func (r *VMRunner) VM() *models.VM {
+func (r *VMRunner) VM() *domain.VM {
 	return r.vm
 }
 
@@ -386,7 +386,7 @@ func (r *VMRunner) VCpuCount() int {
 }
 
 // VCPUPinning returns the vCPU pinning configuration
-func (r *VMRunner) VCPUPinning() models.VCPUPinningGlobal {
+func (r *VMRunner) VCPUPinning() domain.VCPUPinningGlobal {
 	return r.runCfg.VCPUPinning
 }
 
@@ -599,12 +599,12 @@ func (r *VMRunner) Snapshot() (Metrics, error) {
 }
 
 // PCIPassthroughDevices returns the PCI passthrough devices
-func (r *VMRunner) PCIPassthroughDevices() []models.PCIPassthroughDevice {
+func (r *VMRunner) PCIPassthroughDevices() []domain.PCIPassthroughDevice {
 	return r.runCfg.PCIPassthroughConfig.Devices
 }
 
 // USBPassthroughDevices returns the USB passthrough devices
-func (r *VMRunner) USBPassthroughDevices() []models.USBPassthroughDevice {
+func (r *VMRunner) USBPassthroughDevices() []domain.USBPassthroughDevice {
 	return r.runCfg.USBPassthroughConfig.Devices
 }
 

--- a/internal/vm/vm_runner_config.go
+++ b/internal/vm/vm_runner_config.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // buildQEMUArgs constructs the QEMU command line arguments from VM config
@@ -218,7 +218,7 @@ func (r *VMRunner) buildQEMUArgs(vmDataDir string) []string {
 	pciDevices := r.runCfg.PCIPassthroughConfig.Devices
 	// Backward compatibility: if no PCI config but GPUROM is set, use legacy passthrough
 	if len(pciDevices) == 0 && r.vm.GPUROM != "" {
-		pciDevices = []models.PCIPassthroughDevice{
+		pciDevices = []domain.PCIPassthroughDevice{
 			{Address: "0000:01:00.0", ROMPath: r.vm.GPUROM},
 		}
 	}

--- a/internal/vm/vm_runner_pinning.go
+++ b/internal/vm/vm_runner_pinning.go
@@ -5,11 +5,11 @@ import (
 	"log"
 	"sort"
 
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // ApplyVCPUPinning applies thread affinity based on QMP CPU topology and configured mapping.
-func (r *VMRunner) ApplyVCPUPinning(pinning models.VCPUPinningGlobal) error {
+func (r *VMRunner) ApplyVCPUPinning(pinning domain.VCPUPinningGlobal) error {
 	if !pinning.Enabled || len(pinning.Mappings) == 0 {
 		return nil
 	}

--- a/internal/vm/vm_runner_pinning_test.go
+++ b/internal/vm/vm_runner_pinning_test.go
@@ -4,20 +4,20 @@ import (
 	"testing"
 
 	"github.com/glemsom/dkvmmanager/internal/config"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 func TestApplyVCPUPinningNoClient(t *testing.T) {
-	r := NewVMRunner(&models.VM{ID: "1", Name: "t"}, &config.Config{DataFolder: t.TempDir(), QEMUPath: "/bin/true"}, RunConfig{})
-	err := r.ApplyVCPUPinning(models.VCPUPinningGlobal{Enabled: true, Mappings: []models.VCPUToHostMapping{{VCPUID: 0, HostCPUID: 0}}})
+	r := NewVMRunner(&domain.VM{ID: "1", Name: "t"}, &config.Config{DataFolder: t.TempDir(), QEMUPath: "/bin/true"}, RunConfig{})
+	err := r.ApplyVCPUPinning(domain.VCPUPinningGlobal{Enabled: true, Mappings: []domain.VCPUToHostMapping{{VCPUID: 0, HostCPUID: 0}}})
 	if err == nil {
 		t.Fatal("expected error when qmp client is nil")
 	}
 }
 
 func TestApplyVCPUPinningDisabled(t *testing.T) {
-	r := NewVMRunner(&models.VM{ID: "1", Name: "t"}, &config.Config{DataFolder: t.TempDir(), QEMUPath: "/bin/true"}, RunConfig{})
-	if err := r.ApplyVCPUPinning(models.VCPUPinningGlobal{}); err != nil {
+	r := NewVMRunner(&domain.VM{ID: "1", Name: "t"}, &config.Config{DataFolder: t.TempDir(), QEMUPath: "/bin/true"}, RunConfig{})
+	if err := r.ApplyVCPUPinning(domain.VCPUPinningGlobal{}); err != nil {
 		t.Fatalf("disabled pinning should be no-op: %v", err)
 	}
 }

--- a/internal/vm/vm_runner_test.go
+++ b/internal/vm/vm_runner_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/glemsom/dkvmmanager/internal/config"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 func TestValidateOVMFFiles(t *testing.T) {
@@ -29,7 +29,7 @@ func TestValidateOVMFFiles(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
@@ -75,7 +75,7 @@ func TestBuildQEMUArgs(t *testing.T) {
 		NetworkBridge: "br0",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:          "1",
 		Name:        "test-vm",
 		MAC:         "de:ad:be:ef:00:01",
@@ -86,7 +86,7 @@ func TestBuildQEMUArgs(t *testing.T) {
 	}
 
 	runner := NewVMRunner(vm, cfg, RunConfig{
-		CPUTopology: models.CPUTopology{
+		CPUTopology: domain.CPUTopology{
 			Enabled:      true,
 			SelectedCPUs: []int{4, 5, 6, 7},
 		},
@@ -162,7 +162,7 @@ func TestBuildQEMUArgsWithNAT(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:          "1",
 		Name:        "test-vm",
 		MAC:         "de:ad:be:ef:00:01",
@@ -209,7 +209,7 @@ func TestBuildQEMUArgsWithNATDefault(t *testing.T) {
 	}
 
 	// VM with empty NetworkMode should default to NAT
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 		MAC:  "de:ad:be:ef:00:01",
@@ -247,7 +247,7 @@ func TestBuildQEMUArgsBridgeFallbackToNAT(t *testing.T) {
 		// NetworkBridge intentionally empty
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:          "1",
 		Name:        "test-vm",
 		MAC:         "de:ad:be:ef:00:01",
@@ -285,7 +285,7 @@ func TestBuildQEMUArgsUnknownModeDefaultsToNAT(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:          "1",
 		Name:        "test-vm",
 		MAC:         "de:ad:be:ef:00:01",
@@ -314,7 +314,7 @@ func TestBuildQEMUArgsWithVNC(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:        "1",
 		Name:      "test-vm",
 		MAC:       "de:ad:be:ef:00:01",
@@ -340,7 +340,7 @@ func TestNewVMRunner(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
@@ -361,38 +361,38 @@ func TestNewVMRunnerWithRunConfig(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
 
 	runCfg := RunConfig{
 		DryRun: true,
-		CPUOptions: models.CPUOptions{
+		CPUOptions: domain.CPUOptions{
 			HideKVM: true,
 			VendorID: "GenuineIntel",
 		},
-		CPUTopology: models.CPUTopology{
+		CPUTopology: domain.CPUTopology{
 			Enabled:      true,
 			SelectedCPUs: []int{0, 1, 2, 3},
 		},
-		VCPUPinning: models.VCPUPinningGlobal{
+		VCPUPinning: domain.VCPUPinningGlobal{
 			Enabled: true,
-			Mappings: []models.VCPUToHostMapping{
+			Mappings: []domain.VCPUToHostMapping{
 				{VCPUID: 0, HostCPUID: 4},
 			},
 		},
-		PCIPassthroughConfig: models.PCIPassthroughConfig{
-			Devices: []models.PCIPassthroughDevice{
+		PCIPassthroughConfig: domain.PCIPassthroughConfig{
+			Devices: []domain.PCIPassthroughDevice{
 				{Address: "0000:01:00.0", Name: "GPU"},
 			},
 		},
-		USBPassthroughConfig: models.USBPassthroughConfig{
-			Devices: []models.USBPassthroughDevice{
+		USBPassthroughConfig: domain.USBPassthroughConfig{
+			Devices: []domain.USBPassthroughDevice{
 				{Vendor: "046d", Product: "c52b"},
 			},
 		},
-		StartStopScript: models.StartStopScript{
+		StartStopScript: domain.StartStopScript{
 			StartScript: "echo start",
 			StopScript:  "echo stop",
 		},
@@ -435,7 +435,7 @@ func TestCleanupStaleSocket(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{ID: "1", Name: "test"}
+	vm := &domain.VM{ID: "1", Name: "test"}
 	runner := NewVMRunner(vm, cfg, RunConfig{})
 	runner.socketPath = socketPath
 	runner.Cleanup()
@@ -521,7 +521,7 @@ func TestPersistLogWritesLines(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
@@ -569,7 +569,7 @@ func TestPersistLogAppendsOnRestart(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
@@ -625,7 +625,7 @@ func TestPersistLogSlowFlushDoesNotBlock(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
@@ -681,7 +681,7 @@ func TestPersistLogDryRunWritesToFile(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
@@ -738,7 +738,7 @@ func TestPersistLogWriteErrorDoesNotCrash(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
@@ -818,14 +818,14 @@ func TestBuildQEMUArgsWithUSBPassthrough(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
 
 	runner := NewVMRunner(vm, cfg, RunConfig{
-		USBPassthroughConfig: models.USBPassthroughConfig{
-			Devices: []models.USBPassthroughDevice{
+		USBPassthroughConfig: domain.USBPassthroughConfig{
+			Devices: []domain.USBPassthroughDevice{
 				{Vendor: "046d", Product: "c52b", Name: "Logitech Unifying Receiver", BusID: "1-1"},
 				{Vendor: "045e", Product: "028e", Name: "Xbox Controller", BusID: "3-2"},
 			},
@@ -863,7 +863,7 @@ func TestBuildQEMUArgsWithoutUSBPassthrough(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
@@ -902,8 +902,8 @@ func TestDryRunFiltersUSBPassthrough(t *testing.T) {
 
 func TestBuildCPUOptsStringWithCPUPM(t *testing.T) {
 	runner := &VMRunner{
-		vm:     &models.VM{Name: "test"},
-		runCfg: RunConfig{CPUOptions: models.CPUOptions{CPUPM: true}},
+		vm:     &domain.VM{Name: "test"},
+		runCfg: RunConfig{CPUOptions: domain.CPUOptions{CPUPM: true}},
 	}
 
 	result := runner.buildCPUOptsString()
@@ -931,13 +931,13 @@ func TestBuildQEMUArgsWithCPUPM(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
 
 	runner := NewVMRunner(vm, cfg, RunConfig{
-		CPUOptions: models.CPUOptions{CPUPM: true},
+		CPUOptions: domain.CPUOptions{CPUPM: true},
 	})
 	args := runner.buildQEMUArgs(vmDir)
 	argStr := string(joinArgs(args))
@@ -970,7 +970,7 @@ func TestBuildQEMUArgsWithoutCPUPM(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
@@ -1018,13 +1018,13 @@ func TestBuildQEMUArgsWithCPUTopology(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
 
 	runner := NewVMRunner(vm, cfg, RunConfig{
-		CPUTopology: models.CPUTopology{
+		CPUTopology: domain.CPUTopology{
 			Enabled:      true,
 			SelectedCPUs: []int{4, 5, 6, 7},
 		},
@@ -1050,7 +1050,7 @@ func TestBuildQEMUArgsWithoutCPUTopology(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 		// No CPU topology enabled
@@ -1068,8 +1068,8 @@ func TestBuildQEMUArgsWithoutCPUTopology(t *testing.T) {
 
 func TestBuildCPUOptsString(t *testing.T) {
 	runner := &VMRunner{
-		vm:     &models.VM{Name: "test"},
-		runCfg: RunConfig{CPUOptions: models.CPUOptions{
+		vm:     &domain.VM{Name: "test"},
+		runCfg: RunConfig{CPUOptions: domain.CPUOptions{
 			HideKVM:   true,
 			HVRelaxed: true,
 			TopoExt:   true,
@@ -1091,8 +1091,8 @@ func TestBuildCPUOptsString(t *testing.T) {
 
 func TestBuildCPUOptsStringWithHVVendorID(t *testing.T) {
 	runner := &VMRunner{
-		vm:     &models.VM{Name: "test"},
-		runCfg: RunConfig{CPUOptions: models.CPUOptions{
+		vm:     &domain.VM{Name: "test"},
+		runCfg: RunConfig{CPUOptions: domain.CPUOptions{
 			HideKVM:  true,
 			VendorID: "AuthenticAMD",
 		}},
@@ -1114,8 +1114,8 @@ func TestBuildCPUOptsStringWithHVVendorID(t *testing.T) {
 
 func TestBuildCPUOptsStringEmpty(t *testing.T) {
 	runner := &VMRunner{
-		vm:     &models.VM{Name: "test"},
-		runCfg: RunConfig{CPUOptions: models.CPUOptions{}},
+		vm:     &domain.VM{Name: "test"},
+		runCfg: RunConfig{CPUOptions: domain.CPUOptions{}},
 	}
 
 	result := runner.buildCPUOptsString()
@@ -1126,8 +1126,8 @@ func TestBuildCPUOptsStringEmpty(t *testing.T) {
 
 func TestBuildCPUOptsStringWithForceCPUID(t *testing.T) {
 	runner := &VMRunner{
-		vm:     &models.VM{Name: "test"},
-		runCfg: RunConfig{CPUOptions: models.CPUOptions{
+		vm:     &domain.VM{Name: "test"},
+		runCfg: RunConfig{CPUOptions: domain.CPUOptions{
 			ForceCPUID0x80000026: true,
 		}},
 	}
@@ -1141,8 +1141,8 @@ func TestBuildCPUOptsStringWithForceCPUID(t *testing.T) {
 
 func TestBuildCPUOptsStringWithL3CacheSizeDie(t *testing.T) {
 	runner := &VMRunner{
-		vm:     &models.VM{Name: "test"},
-		runCfg: RunConfig{CPUOptions: models.CPUOptions{
+		vm:     &domain.VM{Name: "test"},
+		runCfg: RunConfig{CPUOptions: domain.CPUOptions{
 			L3CacheSizeDie: map[int]string{
 				0: "32M",
 				1: "96M",
@@ -1162,8 +1162,8 @@ func TestBuildCPUOptsStringWithL3CacheSizeDie(t *testing.T) {
 
 func TestBuildCPUOptsStringWithL3CacheSizeDieEmpty(t *testing.T) {
 	runner := &VMRunner{
-		vm:     &models.VM{Name: "test"},
-		runCfg: RunConfig{CPUOptions: models.CPUOptions{
+		vm:     &domain.VM{Name: "test"},
+		runCfg: RunConfig{CPUOptions: domain.CPUOptions{
 			L3CacheSizeDie: map[int]string{},
 		}},
 	}
@@ -1177,8 +1177,8 @@ func TestBuildCPUOptsStringWithL3CacheSizeDieEmpty(t *testing.T) {
 
 func TestBuildCPUOptsStringWithL3CacheAssocDie(t *testing.T) {
 	runner := &VMRunner{
-		vm:     &models.VM{Name: "test"},
-		runCfg: RunConfig{CPUOptions: models.CPUOptions{
+		vm:     &domain.VM{Name: "test"},
+		runCfg: RunConfig{CPUOptions: domain.CPUOptions{
 			L3CacheAssocDie: map[int]int{
 				0: 8,
 				1: 12,
@@ -1198,8 +1198,8 @@ func TestBuildCPUOptsStringWithL3CacheAssocDie(t *testing.T) {
 
 func TestBuildCPUOptsStringWithL3CacheAssocDieEmpty(t *testing.T) {
 	runner := &VMRunner{
-		vm:     &models.VM{Name: "test"},
-		runCfg: RunConfig{CPUOptions: models.CPUOptions{
+		vm:     &domain.VM{Name: "test"},
+		runCfg: RunConfig{CPUOptions: domain.CPUOptions{
 			L3CacheAssocDie: map[int]int{},
 		}},
 	}
@@ -1223,23 +1223,23 @@ func TestBuildQEMUArgsWithHostTopology(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
 
 	// Create host topology: 2 dies, 4 cores per die, 2 threads per core
-	hostTopo := models.HostCPUTopology{
+	hostTopo := domain.HostCPUTopology{
 		TotalCores:      8,
 		TotalCPUs:     16,
 		ThreadsPerCore: 2,
-		Dies: []models.CPUDie{
+		Dies: []domain.CPUDie{
 			{
 				ID:    0,
 				Cores: 4,
 				Threads: 2,
 				LogicalCPUs: []int{0, 1, 2, 3, 4, 5, 6, 7},
-				CoreDetails: []models.CPUCore{
+				CoreDetails: []domain.CPUCore{
 					{ID: 0, DieID: 0, Threads: []int{0, 1}},
 					{ID: 1, DieID: 0, Threads: []int{2, 3}},
 					{ID: 2, DieID: 0, Threads: []int{4, 5}},
@@ -1251,7 +1251,7 @@ func TestBuildQEMUArgsWithHostTopology(t *testing.T) {
 				Cores: 4,
 				Threads: 2,
 				LogicalCPUs: []int{8, 9, 10, 11, 12, 13, 14, 15},
-				CoreDetails: []models.CPUCore{
+				CoreDetails: []domain.CPUCore{
 					{ID: 0, DieID: 1, Threads: []int{8, 9}},
 					{ID: 1, DieID: 1, Threads: []int{10, 11}},
 					{ID: 2, DieID: 1, Threads: []int{12, 13}},
@@ -1263,7 +1263,7 @@ func TestBuildQEMUArgsWithHostTopology(t *testing.T) {
 
 	runner := NewVMRunner(vm, cfg, RunConfig{
 		HostCPUTopology: hostTopo,
-		CPUTopology: models.CPUTopology{
+		CPUTopology: domain.CPUTopology{
 			Enabled:         true,
 			SelectedCPUs:    []int{0, 1, 2, 3},
 			UseHostTopology: true,
@@ -1306,17 +1306,17 @@ func TestBuildQEMUArgsWithHostTopologyInvalidCPU(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
 
 	// Create host topology: 2 dies, 4 cores per die, 2 threads per core
-	hostTopo := models.HostCPUTopology{
+	hostTopo := domain.HostCPUTopology{
 		TotalCores:      8,
 		TotalCPUs:     16,
 		ThreadsPerCore: 2,
-		Dies: []models.CPUDie{
+		Dies: []domain.CPUDie{
 			{ID: 0, Threads: 2, Cores: 4},
 			{ID: 1, Threads: 2, Cores: 4},
 		},
@@ -1324,7 +1324,7 @@ func TestBuildQEMUArgsWithHostTopologyInvalidCPU(t *testing.T) {
 
 	runner := NewVMRunner(vm, cfg, RunConfig{
 		HostCPUTopology: hostTopo,
-		CPUTopology: models.CPUTopology{
+		CPUTopology: domain.CPUTopology{
 			Enabled:         true,
 			SelectedCPUs:    []int{0, 99},
 			UseHostTopology: true,
@@ -1380,7 +1380,7 @@ func TestCleanupPreservesTPMState(t *testing.T) {
 		DataFolder: dir,
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
-	vm := &models.VM{ID: "1", Name: "test"}
+	vm := &domain.VM{ID: "1", Name: "test"}
 	runner := NewVMRunner(vm, cfg, RunConfig{})
 	// Inject fake swtpm process
 	runner.swtpmProcess = fakeProc
@@ -1437,7 +1437,7 @@ func TestStartTPMErrorDoesNotDeleteState(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 		TPMBinary:  "/nonexistent/swtpm-binary", // will fail to start
 	}
-	vm := &models.VM{ID: "1", Name: "test"}
+	vm := &domain.VM{ID: "1", Name: "test"}
 	runner := NewVMRunner(vm, cfg, RunConfig{})
 
 	// startTPM should fail
@@ -1471,7 +1471,7 @@ func TestSubscribeDrainsBufferedLines(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
@@ -1537,7 +1537,7 @@ func TestSubscribeChannelClosedOnExit(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
@@ -1577,7 +1577,7 @@ func TestSubscribeNoDuplicationWithRecentLog(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}
@@ -1662,7 +1662,7 @@ func TestStartTPMOrphanKill(t *testing.T) {
 		QEMUPath:   "/usr/bin/qemu-system-x86_64",
 		TPMBinary:  "/nonexistent/swtpm-binary", // will fail to start
 	}
-	vm := &models.VM{ID: "1", Name: "test"}
+	vm := &domain.VM{ID: "1", Name: "test"}
 	runner := NewVMRunner(vm, cfg, RunConfig{})
 
 	// startTPM should fail (bad binary) but should have killed the orphan first
@@ -1694,7 +1694,7 @@ func TestVMRunnerCmdRaceDocumentation(t *testing.T) {
 	// concurrent-access pattern used by Start() and ForceStop() is race-free.
 	// The actual race detection is done by `go test -race`.
 
-	runner := NewVMRunner(&models.VM{ID: "1", Name: "test"},
+	runner := NewVMRunner(&domain.VM{ID: "1", Name: "test"},
 		&config.Config{QEMUPath: "/bin/true"}, RunConfig{})
 
 	var wg sync.WaitGroup
@@ -1750,7 +1750,7 @@ func TestStartForceStopConcurrent(t *testing.T) {
 		QEMUPath:   "/bin/sleep",
 	}
 
-	vm := &models.VM{
+	vm := &domain.VM{
 		ID:   "1",
 		Name: "test-vm",
 	}

--- a/internal/vm/yaml_integrity_test.go
+++ b/internal/vm/yaml_integrity_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/glemsom/dkvmmanager/internal/config"
-	"github.com/glemsom/dkvmmanager/internal/models"
+	"github.com/glemsom/dkvmmanager/internal/domain"
 )
 
 // TestYAMLIntegrityAfterSave tests the actual YAML file after save operations
@@ -49,7 +49,7 @@ func TestYAMLIntegrityAfterSave(t *testing.T) {
 	// Now edit VM1 (simulating the edit model flow)
 	// First, load VM1 (like NewVMEditModel does)
 	allVMs, _ := mgr.ListVMs()
-	var targetVM *models.VM
+	var targetVM *domain.VM
 	for i := range allVMs {
 		if allVMs[i].ID == vm1.ID {
 			targetVM = &allVMs[i]
@@ -163,7 +163,7 @@ func TestRepositorySavePreservesOtherVMs(t *testing.T) {
 	}
 
 	// Save VM 0
-	vm0 := &models.VM{
+	vm0 := &domain.VM{
 		ID:        "0",
 		Name:      "vm-zero",
 		HardDisks: []string{"/dev/sda"},
@@ -174,7 +174,7 @@ func TestRepositorySavePreservesOtherVMs(t *testing.T) {
 	repo.SaveVM(vm0)
 
 	// Save VM 1
-	vm1 := &models.VM{
+	vm1 := &domain.VM{
 		ID:        "1",
 		Name:      "vm-one",
 		HardDisks: []string{"/dev/sdb"},


### PR DESCRIPTION
Resolves #128

Renames `internal/models` → `internal/domain` to resolve import-path collision with `internal/tui/models`.

**Changes:**
- `mv internal/models internal/domain`
- `models.go` → `types.go`, `models_test.go` → `types_test.go`
- Package name: `models` → `domain`
- All 67 Go import references updated (no alias needed anymore)
- Doc files updated: `CHANGELOG.md`, `docs/dev/architecture.md`, `docs/reference/vm-config.md`, `docs/user/scripts-and-ssh.md`

**Verification:**
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ (all 13 packages pass)