### PR TITLE
feat: CPU and memory trend sparklines in running VM view (#137)

### DIFF
--- a/internal/tui/models/vm_running.go
+++ b/internal/tui/models/vm_running.go
@@ -58,6 +58,76 @@ type VMMetricsUpdateMsg struct {
 	Metrics vm.Metrics
 }
 
+// sparklineBuffer is a fixed-capacity circular buffer for trend data.
+// push overwrites the oldest value when full.
+// snapshot returns all buffered values in insertion order.
+type sparklineBuffer struct {
+	values []float64
+	cursor int
+	count  int
+	cap    int
+}
+
+func newSparklineBuffer(cap int) sparklineBuffer {
+	return sparklineBuffer{
+		values: make([]float64, cap),
+		cap:    cap,
+	}
+}
+
+func (b *sparklineBuffer) push(v float64) {
+	if b.cap == 0 {
+		// Lazy-init with default capacity if created zero-valued
+		b.cap = 30
+		b.values = make([]float64, b.cap)
+	} else if b.values == nil {
+		b.values = make([]float64, b.cap)
+	}
+	b.values[b.cursor] = v
+	b.cursor = (b.cursor + 1) % b.cap
+	if b.count < b.cap {
+		b.count++
+	}
+}
+
+func (b *sparklineBuffer) snapshot() []float64 {
+	if b.count == 0 {
+		return nil
+	}
+	out := make([]float64, b.count)
+	if b.count < b.cap {
+		copy(out, b.values[:b.count])
+		return out
+	}
+	copy(out, b.values[b.cursor:])
+	copy(out[b.cap-b.cursor:], b.values[:b.cursor])
+	return out
+}
+
+func (b *sparklineBuffer) peak() float64 {
+	vals := b.snapshot()
+	if len(vals) == 0 {
+		return 0
+	}
+	p := vals[0]
+	for _, v := range vals[1:] {
+		if v > p {
+			p = v
+		}
+	}
+	return p
+}
+
+func (b *sparklineBuffer) latest() (float64, bool) {
+	if b.count == 0 {
+		return 0, false
+	}
+	if b.cursor == 0 {
+		return b.values[b.cap-1], true
+	}
+	return b.values[b.cursor-1], true
+}
+
 // VMRunningModel displays a running VM with log output and status
 type VMRunningModel struct {
 	// VM info
@@ -85,6 +155,10 @@ type VMRunningModel struct {
 	// Metrics snapshot (latest, updated every 2s)
 	metrics vm.Metrics
 
+	// Sparkline trend buffers (60-second window at 2 s cadence → cap=30)
+	cpuTrend sparklineBuffer // aggregate CPU% (×100 fixed-point)
+	memTrend sparklineBuffer // HostRSSBytes
+
 	// Dimensions
 	width  int
 	height int
@@ -104,6 +178,8 @@ func NewVMRunningModel(vmObj *domain.VM, runner *vm.VMRunner) *VMRunningModel {
 		vm:          vmObj,
 		runner:      runner,
 		maxLogLines: 500,
+		cpuTrend:    newSparklineBuffer(30),
+		memTrend:    newSparklineBuffer(30),
 	}
 }
 
@@ -336,6 +412,20 @@ func (m *VMRunningModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case VMMetricsUpdateMsg:
 		m.metrics = msg.Metrics
+
+		// Push aggregate CPU% and RSS into trend buffers
+		if len(msg.Metrics.VCPUs) > 0 {
+			var totalCPU float64
+			for _, vcpu := range msg.Metrics.VCPUs {
+				totalCPU += float64(vcpu.CPUTimeNs)
+			}
+			// CPUTimeNs holds CPU% ×100; push as-is, divide later for display
+			m.cpuTrend.push(totalCPU)
+		}
+		if msg.Metrics.HostRSSBytes > 0 {
+			m.memTrend.push(float64(msg.Metrics.HostRSSBytes))
+		}
+
 		return m, m.pollMetrics()
 
 	case VMStartedMsg:
@@ -431,6 +521,10 @@ func (m *VMRunningModel) calculateInfoHeight() int {
 	if m.metrics.HostRSSBytes > 0 || m.metrics.HostCPUJiffies > 0 {
 		height++
 	}
+
+	// #137: Add 2 lines for CPU and memory trend sparklines
+	// Always present to avoid layout shift (placeholder when empty).
+	height += 2
 
 	// S5: Add one line per block device for per-disk IOPS/B/s display.
 	if len(m.metrics.BlockDevices) > 0 {
@@ -641,6 +735,49 @@ func (m *VMRunningModel) renderInfoPanel() string {
 		b.WriteString("  ")
 		b.WriteString(labelStyle.Render("RSS "))
 		b.WriteString(valueStyle.Render(formatBytes(m.metrics.HostRSSBytes)))
+		b.WriteString("\n")
+	}
+
+	// === Section: CPU and Memory Trend Sparklines (#137) ===
+	// Always present to avoid layout shift (placeholder when empty).
+	// CPU sparkline: 20 braille chars wide, shows aggregate CPU% + peak.
+	cpuVals := m.cpuTrend.snapshot()
+	if len(cpuVals) > 0 {
+		spark := RenderBrailleSparkline(cpuVals, 20)
+		latestCPU, _ := m.cpuTrend.latest()
+		pk := m.cpuTrend.peak()
+		b.WriteString(labelStyle.Render("CPU: "))
+		b.WriteString(valueStyle.Render(spark))
+		b.WriteString("  ")
+		b.WriteString(valueStyle.Render(fmt.Sprintf("%.1f%%", latestCPU/100.0)))
+		b.WriteString(labelStyle.Render("  peak "))
+		b.WriteString(valueStyle.Render(fmt.Sprintf("%.1f%%", pk/100.0)))
+		b.WriteString("\n")
+	} else {
+		b.WriteString(labelStyle.Render("CPU: "))
+		b.WriteString(valueStyle.Render("⋯⋯⋯⋯⋯⋯⋯⋯⋯⋯"))
+		b.WriteString("\n")
+	}
+
+	// Mem sparkline: 20 braille chars wide, shows current RSS + total guest memory.
+	memVals := m.memTrend.snapshot()
+	if len(memVals) > 0 {
+		spark := RenderBrailleSparkline(memVals, 20)
+		latestMem, _ := m.memTrend.latest()
+		memLabel := fmt.Sprintf("  %s", formatBytes(uint64(latestMem)))
+		if m.runner != nil {
+			memTotal := m.runner.MemoryMB() * 1024 * 1024
+			memLabel += fmt.Sprintf(" / %s", formatBytes(uint64(memTotal)))
+		} else {
+			memLabel += " N/A"
+		}
+		b.WriteString(labelStyle.Render("Mem: "))
+		b.WriteString(valueStyle.Render(spark))
+		b.WriteString(mutedStyle.Render(memLabel))
+		b.WriteString("\n")
+	} else {
+		b.WriteString(labelStyle.Render("Mem: "))
+		b.WriteString(valueStyle.Render("⋯⋯⋯⋯⋯⋯⋯⋯⋯⋯"))
 		b.WriteString("\n")
 	}
 

--- a/internal/tui/models/vm_running_test.go
+++ b/internal/tui/models/vm_running_test.go
@@ -168,8 +168,8 @@ func TestVMRunningModelWindowSizeUpdate(t *testing.T) {
 	if m.vp.Width() != 100 {
 		t.Errorf("Expected viewport width 100, got %d", m.vp.Width())
 	}
-	if m.vp.Height() != 23 { // 30 - infoHeight(4) - 3 = 23
-		t.Errorf("Expected viewport height 23, got %d", m.vp.Height())
+	if m.vp.Height() != 21 { // 30 - infoHeight(6) - 3 = 21
+		t.Errorf("Expected viewport height 21, got %d", m.vp.Height())
 	}
 }
 
@@ -201,8 +201,8 @@ func TestVMRunningModelSetSizeTwice(t *testing.T) {
 	if m.vp.Width() != 120 {
 		t.Errorf("Expected viewport width 120, got %d", m.vp.Width())
 	}
-	if m.vp.Height() != 33 { // 40 - infoHeight(4) - 3 = 33
-		t.Errorf("Expected viewport height 33, got %d", m.vp.Height())
+	if m.vp.Height() != 31 { // 40 - infoHeight(6) - 3 = 31
+		t.Errorf("Expected viewport height 31, got %d", m.vp.Height())
 	}
 }
 
@@ -684,6 +684,139 @@ func TestVMRunningModelMultipleDisksRendering(t *testing.T) {
 	}
 	if !strings.Contains(viewContent, "drive1") {
 		t.Error("View should contain 'drive1' for second disk")
+	}
+}
+
+// #137: sparklineBuffer circular buffer tests
+func TestSparklineBufferPushAndSnapshot(t *testing.T) {
+	b := newSparklineBuffer(5)
+	b.push(1)
+	b.push(2)
+	b.push(3)
+	got := b.snapshot()
+	if len(got) != 3 {
+		t.Fatalf("snapshot len = %d, want 3", len(got))
+	}
+	if got[0] != 1 || got[1] != 2 || got[2] != 3 {
+		t.Errorf("snapshot = %v, want [1 2 3]", got)
+	}
+}
+
+func TestSparklineBufferWraparound(t *testing.T) {
+	b := newSparklineBuffer(3)
+	b.push(10)
+	b.push(20)
+	b.push(30)
+	b.push(40) // overwrites values[0]
+	b.push(50) // overwrites values[1]
+	got := b.snapshot()
+	if len(got) != 3 {
+		t.Fatalf("snapshot len = %d, want 3", len(got))
+	}
+	if got[0] != 30 || got[1] != 40 || got[2] != 50 {
+		t.Errorf("after wrap snapshot = %v, want [30 40 50]", got)
+	}
+}
+
+func TestSparklineBufferEmptySnapshot(t *testing.T) {
+	b := newSparklineBuffer(5)
+	if got := b.snapshot(); got != nil {
+		t.Errorf("empty snapshot = %v, want nil", got)
+	}
+}
+
+func TestSparklineBufferLatest(t *testing.T) {
+	b := newSparklineBuffer(5)
+	if _, ok := b.latest(); ok {
+		t.Error("empty buffer latest() should return false")
+	}
+	b.push(42)
+	v, ok := b.latest()
+	if !ok {
+		t.Fatal("latest() after push should return true")
+	}
+	if v != 42 {
+		t.Errorf("latest() = %v, want 42", v)
+	}
+	b.push(99)
+	v, _ = b.latest()
+	if v != 99 {
+		t.Errorf("latest() after second push = %v, want 99", v)
+	}
+}
+
+func TestSparklineBufferPeak(t *testing.T) {
+	b := newSparklineBuffer(10)
+	b.push(5)
+	b.push(3)
+	b.push(8)
+	b.push(2)
+	if p := b.peak(); p != 8 {
+		t.Errorf("peak = %v, want 8", p)
+	}
+}
+
+func TestSparklineBufferEmptyPeak(t *testing.T) {
+	b := newSparklineBuffer(5)
+	if p := b.peak(); p != 0 {
+		t.Errorf("empty peak = %v, want 0", p)
+	}
+}
+
+func TestSparklineBufferZeroValueLazyInit(t *testing.T) {
+	// A zero-valued sparklineBuffer should init on first push.
+	var b sparklineBuffer // zero value: all fields 0
+	b.push(100)
+	got := b.snapshot()
+	if len(got) != 1 || got[0] != 100 {
+		t.Errorf("lazy-init snapshot = %v, want [100]", got)
+	}
+}
+
+func TestVMRunningModelCPUTrendPushedOnMetricsUpdate(t *testing.T) {
+	m := setupRunningModel(t, "running")
+	// Send metrics update with VCPU data (CPU% ×100 in CPUTimeNs)
+	metrics := vm.Metrics{
+		VCPUs: []vm.VCPUStat{
+			{ThreadID: 100, CPUTimeNs: 1500}, // 15.00%
+			{ThreadID: 101, CPUTimeNs: 2500}, // 25.00%
+		},
+	}
+	upd, _ := m.Update(VMMetricsUpdateMsg{Metrics: metrics})
+	m2 := upd.(*VMRunningModel)
+	vals := m2.cpuTrend.snapshot()
+	if len(vals) != 1 {
+		t.Fatalf("expected 1 cpu trend value, got %d: %v", len(vals), vals)
+	}
+	// Sum should be 1500 + 2500 = 4000
+	if vals[0] != 4000 {
+		t.Errorf("cpu trend value = %v, want 4000 (sum of CPUTimeNs)", vals[0])
+	}
+}
+
+func TestVMRunningModelMemTrendPushedOnMetricsUpdate(t *testing.T) {
+	m := setupRunningModel(t, "running")
+	metrics := vm.Metrics{
+		HostRSSBytes: 512 * 1024 * 1024, // 512 MiB
+	}
+	upd, _ := m.Update(VMMetricsUpdateMsg{Metrics: metrics})
+	m2 := upd.(*VMRunningModel)
+	vals := m2.memTrend.snapshot()
+	if len(vals) != 1 {
+		t.Fatalf("expected 1 mem trend value, got %d", len(vals))
+	}
+	if vals[0] != 512*1024*1024 {
+		t.Errorf("mem trend value = %v, want 512 MiB", vals[0])
+	}
+}
+
+func TestVMRunningModelSparklinePlaceholderWhenEmpty(t *testing.T) {
+	// When buffers are empty, the info panel should show placeholder dots.
+	m := setupRunningModel(t, "running")
+	m.SetSize(100, 30)
+	view := m.View().Content
+	if !strings.Contains(view, "⋯⋯⋯⋯⋯⋯⋯⋯⋯⋯") {
+		t.Error("expected placeholder dots in view when sparkline buffers empty")
 	}
 }
 


### PR DESCRIPTION
Implements #137.

**Changes:**
- Add  circular buffer type (cap=30, 60s window)
- Wire  and  into 
- Push aggregate CPU% and HostRSSBytes on each 
- Render two sparkline lines in info panel (20 braille chars wide)
- CPU line: sparkline + current% + peak%
- Mem line: sparkline + current RSS + total guest memory
- Placeholder dots (U+22EF) when buffer empty
-  adds 2 for sparkline lines
- 10 new tests