### PR TITLE
feat: live network I/O metrics in running VM view

### DIFF
--- a/internal/tui/models/vm_running.go
+++ b/internal/tui/models/vm_running.go
@@ -531,7 +531,18 @@ func (m *VMRunningModel) calculateInfoHeight() int {
 		height += len(m.metrics.BlockDevices)
 	}
 
-	// S5: Add a line for the balloon when populated (graceful degradation
+	// S6: Add network device section when devices are present.
+	// Capped at 2 visible lines; if more devices exist, an overflow
+	// indicator line is added so the total is min(2, len) + 1.
+	if len(m.metrics.NetDevices) > 0 {
+		show := len(m.metrics.NetDevices)
+		if show > 2 {
+			show = 2
+			height++ // overflow indicator line
+		}
+		height += show
+	}
+
 	// hides it when 0).
 	if m.metrics.BalloonBytes > 0 {
 		height++
@@ -807,6 +818,39 @@ func (m *VMRunningModel) renderInfoPanel() string {
 	// Only render when BalloonBytes > 0 (graceful degradation: no balloon
 	// driver is a normal guest configuration, not a "0 B" failure).
 	if m.metrics.BalloonBytes > 0 {
+
+	// === Section: Network Metrics (S6) ===
+	// Capped at 2 devices; overflow indicator shows remaining count.
+	// Format: "net <device>: r: <B/s> · <pps>  w: <B/s> · <pps>".
+	// No section when NetDevices is empty.
+	if len(m.metrics.NetDevices) > 0 {
+		show := len(m.metrics.NetDevices)
+		overflow := 0
+		if show > 2 {
+			overflow = show - 2
+			show = 2
+		}
+		for i := 0; i < show; i++ {
+			dev := m.metrics.NetDevices[i]
+			b.WriteString(labelStyle.Render("net "))
+			b.WriteString(valueStyle.Render(dev.Device))
+			b.WriteString(labelStyle.Render(": "))
+			b.WriteString(labelStyle.Render("r: "))
+			b.WriteString(valueStyle.Render(formatRate(dev.RXBps)))
+			b.WriteString(labelStyle.Render(" · "))
+			b.WriteString(valueStyle.Render(fmt.Sprintf("%d pps", dev.RXPps)))
+			b.WriteString(labelStyle.Render("  w: "))
+			b.WriteString(valueStyle.Render(formatRate(dev.TXBps)))
+			b.WriteString(labelStyle.Render(" · "))
+			b.WriteString(valueStyle.Render(fmt.Sprintf("%d pps", dev.TXPps)))
+			b.WriteString("\n")
+		}
+		if overflow > 0 {
+			b.WriteString(labelStyle.Render(fmt.Sprintf("(+%d more)", overflow)))
+			b.WriteString("\n")
+		}
+	}
+
 		b.WriteString(labelStyle.Render("Balloon: "))
 		b.WriteString(valueStyle.Render(formatBytes(m.metrics.BalloonBytes)))
 		b.WriteString("\n")

--- a/internal/vm/metrics.go
+++ b/internal/vm/metrics.go
@@ -18,6 +18,7 @@ type Metrics struct {
 	// Guest / QMP
 	VCPUs        []VCPUStat  // per-vCPU thread id + total CPU time in ns
 	BlockDevices []BlockStat // per-block r/w bytes, r/w operations (raw counters)
+	NetDevices   []NetStat   // per-netdev r/w bytes, r/w packets (derived rates)
 	BalloonBytes uint64      // from query-balloon; 0 if not available
 
 	// Host /proc/<qemu-pid>
@@ -50,4 +51,25 @@ type BlockStat struct {
 	WRBps  uint64 // bytes written per second
 	RDIOPS uint64 // read operations per second
 	WRIOPS uint64 // write operations per second
+}
+
+// NetStat holds per-network-device statistics for a single snapshot.
+// Raw counters (RXBytes/TXBytes/RXPackets/TXPackets) come from QMP query-netdev.
+// Derived rates (RXBps/TXBps/RXPps/TXPps) are computed from deltas against
+// the previous snapshot by the runner; the view consumes the already-derived
+// numbers directly. On a cold snapshot the rate fields are zero.
+type NetStat struct {
+	Device string // e.g. "hostnet0"
+	RXBytes uint64 // cumulative RX bytes since VM start
+	TXBytes uint64 // cumulative TX bytes since VM start
+	RXPackets uint64 // cumulative RX packets since VM start
+	TXPackets uint64 // cumulative TX packets since VM start
+
+	// Derived (per-second, populated from delta math in Snapshot()).
+	// Cold snapshot leaves these at zero. Negative or wrapped counters
+	// (QEMU counter reset) also leave these at zero rather than going negative.
+	RXBps  uint64 // bytes received per second
+	TXBps  uint64 // bytes transmitted per second
+	RXPps  uint64 // packets received per second
+	TXPps  uint64 // packets transmitted per second
 }

--- a/internal/vm/metrics_test.go
+++ b/internal/vm/metrics_test.go
@@ -438,6 +438,8 @@ func (c *countingBlockClient) QueryBlockStats() ([]QMPBlockDeviceStats, error) {
 			WROps:   c.wrOps(),
 		}},
 	}, nil
+
+
 }
 
 // S5: when the guest has no balloon driver, the QueryBalloon call inside

--- a/internal/vm/mock_netdev_test.go
+++ b/internal/vm/mock_netdev_test.go
@@ -1,0 +1,10 @@
+package vm
+
+func (m *mockQMPClient) QueryNetdev() ([]QMPNetDeviceStats, error) {
+	if m.qError != nil {
+		return nil, m.qError
+	}
+	return nil, nil
+}
+
+func (c *countingBlockClient) QueryNetdev() ([]QMPNetDeviceStats, error) { return nil, nil }

--- a/internal/vm/qmp_client.go
+++ b/internal/vm/qmp_client.go
@@ -47,6 +47,7 @@ type QMPClientInterface interface {
 	QueryCPUs() ([]VCPUInfo, error)
 	QueryCPUsFast() ([]QMPVCPUInfo, error)
 	QueryBlockStats() ([]QMPBlockDeviceStats, error)
+	QueryNetdev() ([]QMPNetDeviceStats, error)
 	QueryBalloon() (uint64, error)
 	Close() error
 	Quit() error
@@ -348,6 +349,24 @@ type QMPBlockDeviceIO struct {
 	WROps   uint64 `json:"wr_operations"`
 }
 
+// QMPNetDeviceIO is the per-device network counter object inside
+// query-netdev. All counters are cumulative since VM start; the
+// runner computes B/s and Pps from deltas across successive snapshots.
+type QMPNetDeviceIO struct {
+	RXBytes   uint64 `json:"rx-bytes"`
+	TXBytes   uint64 `json:"tx-bytes"`
+	RXPackets uint64 `json:"rx-packets"`
+	TXPackets uint64 `json:"tx-packets"`
+}
+
+// QMPNetDeviceStats is one element of the query-netdev return
+// array. The QMP wire format nests the counters under "stats".
+type QMPNetDeviceStats struct {
+	ID    string         `json:"id"`
+	Type  string         `json:"type"`
+	Stats QMPNetDeviceIO `json:"stats"`
+}
+
 // QueryBalloon returns the current balloon size in bytes via query-balloon.
 // The QMP response shape is {"return": {"actual": N, "mem_period": ..., "max": N}}.
 //
@@ -394,6 +413,25 @@ func (c *QMPClient) QueryBlockStats() ([]QMPBlockDeviceStats, error) {
 	var stats []QMPBlockDeviceStats
 	if err := json.Unmarshal(resp.Return, &stats); err != nil {
 		return nil, fmt.Errorf("failed to parse query-blockstats response: %w", err)
+	}
+	return stats, nil
+}
+
+// QueryNetdev returns per-network-device I/O counters via query-netdev.
+// Each element carries r/w bytes and r/w packet counts since VM start;
+// the runner computes B/s and Pps from deltas across successive snapshots.
+func (c *QMPClient) QueryNetdev() ([]QMPNetDeviceStats, error) {
+	resp, err := c.Execute("query-netdev", nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Error != nil {
+		return nil, fmt.Errorf("query-netdev error: %s: %s", resp.Error.Class, resp.Error.Desc)
+	}
+
+	var stats []QMPNetDeviceStats
+	if err := json.Unmarshal(resp.Return, &stats); err != nil {
+		return nil, fmt.Errorf("failed to parse query-netdev response: %w", err)
 	}
 	return stats, nil
 }

--- a/internal/vm/vm_runner.go
+++ b/internal/vm/vm_runner.go
@@ -59,6 +59,8 @@ type VMRunner struct {
 	prevHostJiffies  uint64                      // previous utime+stime for the QEMU process (raw jiffies)
 	prevSnapshotTime time.Time                   // wall clock of previous snapshot
 	prevBlockStats   map[string]QMPBlockDeviceIO // Device -> previous raw counters
+	prevNetStats   map[string]QMPNetDeviceIO // Device -> previous raw counters
+	prevNetTime    time.Time                   // wall clock of previous net snapshot (delta math)
 	prevBlockTime    time.Time                   // wall clock of previous block snapshot (delta math)
 
 	// Proc reader function (overridable for tests)
@@ -415,6 +417,7 @@ func (r *VMRunner) Snapshot() (Metrics, error) {
 	// (0, nil) when the guest has no balloon driver), so a nil error
 	// here is the normal case. query-blockstats returns the raw counter
 	// snapshot; delta math happens below under the lock.
+	var netStats []QMPNetDeviceStats
 	var blockStats []QMPBlockDeviceStats
 	if client != nil {
 		bs, err := client.QueryBlockStats()
@@ -441,6 +444,21 @@ func (r *VMRunner) Snapshot() (Metrics, error) {
 			}
 		} else {
 			m.BalloonBytes = balloon
+
+		}
+
+		// S6: QMP query-netdev.
+		ns, err := client.QueryNetdev()
+		if err != nil {
+			// Graceful degradation on transient QMP failure.
+			if r.dbgMode {
+				log.Printf("[DEBUG] Snapshot: query-netdev failed: %v", err)
+			}
+			if snapshotErr == nil {
+				snapshotErr = fmt.Errorf("Snapshot: query-netdev failed: %w", err)
+			}
+		} else {
+			netStats = ns
 		}
 	}
 
@@ -582,6 +600,53 @@ func (r *VMRunner) Snapshot() (Metrics, error) {
 		r.prevBlockTime = now
 
 		m.BlockDevices = derived
+	}
+
+	// S6: Network device per-device B/s and Pps from deltas.
+	// Same pattern as block stats: (raw_counter_now - raw_counter_prev) / delta_seconds.
+	if len(netStats) > 0 {
+		var derived []NetStat
+		for _, n := range netStats {
+			ns := NetStat{
+				Device:    n.ID,
+				RXBytes:   n.Stats.RXBytes,
+				TXBytes:   n.Stats.TXBytes,
+				RXPackets: n.Stats.RXPackets,
+				TXPackets: n.Stats.TXPackets,
+			}
+
+			// Delta math: only if we have a previous sample for this device
+			// and a positive wall-clock delta.
+			if r.prevNetStats != nil && !r.prevNetTime.IsZero() {
+				prev, exists := r.prevNetStats[n.ID]
+				deltaSecs := now.Sub(r.prevNetTime).Seconds()
+				if exists && deltaSecs > 0 {
+					if n.Stats.RXBytes >= prev.RXBytes {
+						ns.RXBps = uint64(float64(n.Stats.RXBytes-prev.RXBytes) / deltaSecs)
+					}
+					if n.Stats.TXBytes >= prev.TXBytes {
+						ns.TXBps = uint64(float64(n.Stats.TXBytes-prev.TXBytes) / deltaSecs)
+					}
+					if n.Stats.RXPackets >= prev.RXPackets {
+						ns.RXPps = uint64(float64(n.Stats.RXPackets-prev.RXPackets) / deltaSecs)
+					}
+					if n.Stats.TXPackets >= prev.TXPackets {
+						ns.TXPps = uint64(float64(n.Stats.TXPackets-prev.TXPackets) / deltaSecs)
+					}
+				}
+			}
+
+			derived = append(derived, ns)
+		}
+
+		// Update previous state for next delta math.
+		r.prevNetStats = make(map[string]QMPNetDeviceIO, len(netStats))
+		for _, n := range netStats {
+			r.prevNetStats[n.ID] = n.Stats
+		}
+		r.prevNetTime = now
+
+		m.NetDevices = derived
 	}
 
 	return m, snapshotErr


### PR DESCRIPTION
Implements #136 — full vertical slice for `query-netdev`:

**Data layer** — `NetStat` type in `internal/vm/metrics.go` with `Device`, `RXBps`, `TXBps`, `RXPps`, `TXPps` (derived rates). `Metrics.NetDevices` field added.

**QMP layer** — `QMPNetDeviceStats` / `QMPNetDeviceIO` types for the `query-netdev` response. `QMPClient.QueryNetdev()` method, added to `QMPClientInterface`.

**Runner layer** — `VMRunner.Snapshot()` calls `QueryNetdev()`, diffs cumulative counters against `prevNetStats` map, populates `Metrics.NetDevices` with derived per-second rates. First tick per device yields zero rates.

**View layer** — Network section renders after block devices and before balloon in renderInfoPanel, capped at 2 devices with overflow indicator. `calculateInfoHeight()` accounts for net section. Section absent when `NetDevices` is empty.

Closes #136