### PR TITLE
fix(vm-runner): prevent channel deadlocks when buffer full with no reader

### DIFF
--- a/internal/vm/vm_runner.go
+++ b/internal/vm/vm_runner.go
@@ -104,15 +104,7 @@ func (r *VMRunner) Subscribe() <-chan string {
 	r.subsMu.Lock()
 	// Drain staging buffer into the new channel
 	for _, line := range r.staging {
-		select {
-		case ch <- line:
-		default:
-			select {
-			case <-ch:
-			default:
-			}
-			ch <- line
-		}
+		trySendOrDrop(ch, line)
 	}
 	r.staging = nil
 	r.subscribers[ch] = struct{}{}
@@ -260,6 +252,29 @@ func (r *VMRunner) writePersistLine(line string) {
 	_ = r.persistBuf.Flush()
 }
 
+// trySendOrDrop attempts to send a line to a channel. If the channel is full,
+// it drains one item (drops oldest) then tries a non-blocking send.
+// If the send still fails, the line is dropped silently.
+// This prevents deadlocks when the channel is full and no goroutine is reading.
+func trySendOrDrop(ch chan string, line string) {
+	select {
+	case ch <- line:
+	default:
+		// Channel full — drain one to make room
+		select {
+		case <-ch:
+			// One slot freed, try non-blocking send
+			select {
+			case ch <- line:
+			default:
+				// Still full, drop the line
+			}
+		default:
+			// No reader ready, drop the line
+		}
+	}
+}
+
 // forwardViewLine sends a line to all registered subscriber channels.
 // If no subscribers exist, the line is buffered in the staging buffer
 // (up to stagingMax) for future subscribers to drain.
@@ -277,16 +292,7 @@ func (r *VMRunner) forwardViewLine(line string) {
 	}
 
 	for ch := range r.subscribers {
-		select {
-		case ch <- line:
-		default:
-			// Channel full, drop oldest
-			select {
-			case <-ch:
-			default:
-			}
-			ch <- line
-		}
+		trySendOrDrop(ch, line)
 	}
 }
 
@@ -1144,16 +1150,7 @@ func (r *VMRunner) readOutput(pipe io.Reader, source string) {
 		if r.dbgMode {
 			log.Printf("[DEBUG] [%s] %s", source, line)
 		}
-		select {
-		case r.logChan <- prefix + line:
-		default:
-			// Channel full, drop oldest
-			select {
-			case <-r.logChan:
-			default:
-			}
-			r.logChan <- prefix + line
-		}
+		trySendOrDrop(r.logChan, prefix+line)
 	}
 	// Scanner ended - check error
 	if err := scanner.Err(); err != nil {
@@ -1178,16 +1175,7 @@ func (r *VMRunner) readScriptOutput(pipe io.Reader, source string) {
 			prefix = "[stop ERR] "
 		}
 		// Always send to log channel for UI display
-		select {
-		case r.logChan <- prefix + line:
-		default:
-			// Channel full, drop oldest
-			select {
-			case <-r.logChan:
-			default:
-			}
-			r.logChan <- prefix + line
-		}
+		trySendOrDrop(r.logChan, prefix+line)
 		// Also log in debug mode
 		if r.dbgMode {
 			log.Printf("[DEBUG] %s: %s", source, line)
@@ -1330,16 +1318,16 @@ func (r *VMRunner) connectQMP() {
 			r.qmpClient = client
 			r.mu.Unlock()
 
-			r.logChan <- "[QMP] Connected to QEMU monitor"
+			trySendOrDrop(r.logChan, "[QMP] Connected to QEMU monitor")
 			if err := r.ApplyVCPUPinning(r.runCfg.VCPUPinning); err != nil {
-				r.logChan <- fmt.Sprintf("[vCPU pinning] WARNING: %v", err)
+				trySendOrDrop(r.logChan, fmt.Sprintf("[vCPU pinning] WARNING: %v", err))
 			}
 			return
 		}
 		time.Sleep(1 * time.Second)
 	}
 
-	r.logChan <- "[QMP] WARNING: Failed to connect to QMP after timeout"
+	trySendOrDrop(r.logChan, "[QMP] WARNING: Failed to connect to QMP after timeout")
 }
 
 // filterPassthroughArgs removes PCI/USB passthrough and drive ROM arguments

--- a/internal/vm/vm_runner_test.go
+++ b/internal/vm/vm_runner_test.go
@@ -1790,3 +1790,136 @@ func TestStartForceStopConcurrent(t *testing.T) {
 	runner.running = false
 	runner.mu.Unlock()
 }
+
+// --- Channel deadlock prevention tests ---
+
+func TestTrySendOrDropDoesNotBlockWhenFullNoReader(t *testing.T) {
+	t.Parallel()
+	// Channel with no reader and full buffer must not block.
+	ch := make(chan string, 3)
+	// Fill it
+	for i := 0; i < 3; i++ {
+		ch <- "dummy"
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			trySendOrDrop(ch, "test")
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All sends completed without blocking
+	case <-time.After(3 * time.Second):
+		t.Fatal("trySendOrDrop blocked on full channel with no reader")
+	}
+}
+
+func TestForwardViewLineDoesNotBlockWhenFullNoReader(t *testing.T) {
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vms", "1")
+	os.MkdirAll(vmDir, 0755)
+
+	cfg := &config.Config{
+		DataFolder: dir,
+		QEMUPath:   "/usr/bin/qemu-system-x86_64",
+	}
+	vm := &domain.VM{ID: "1", Name: "test-vm"}
+	runner := NewVMRunner(vm, cfg, RunConfig{}, false)
+
+	// Manually add a subscriber channel that's already full and has no reader.
+	fullCh := make(chan string, 3)
+	for i := 0; i < 3; i++ {
+		fullCh <- "filler"
+	}
+	runner.subsMu.Lock()
+	runner.subscribers[fullCh] = struct{}{}
+	runner.subsMu.Unlock()
+
+	// forwardViewLine must not block.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 500; i++ {
+			runner.forwardViewLine(fmt.Sprintf("line %d", i))
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All forwards completed without blocking
+	case <-time.After(3 * time.Second):
+		t.Fatal("forwardViewLine blocked on full subscriber with no reader")
+	}
+}
+
+func TestLogChanDoesNotBlockWhenFullNoReader(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vms", "1")
+	os.MkdirAll(vmDir, 0755)
+
+	cfg := &config.Config{
+		DataFolder: dir,
+		QEMUPath:   "/usr/bin/qemu-system-x86_64",
+	}
+	vm := &domain.VM{ID: "1", Name: "test-vm"}
+	runner := NewVMRunner(vm, cfg, RunConfig{}, false)
+	// Do NOT start persistLogLoop — no reader on logChan.
+	// Direct writes to logChan must not block.
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 500; i++ {
+			trySendOrDrop(runner.logChan, fmt.Sprintf("line %d", i))
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All sends completed without blocking
+	case <-time.After(5 * time.Second):
+		t.Fatal("trySendOrDrop blocked on logChan with no reader")
+	}
+}
+
+func TestConnectQMPWritesDroppedGracefully(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vms", "1")
+	os.MkdirAll(vmDir, 0755)
+
+	cfg := &config.Config{
+		DataFolder: dir,
+		QEMUPath:   "/usr/bin/qemu-system-x86_64",
+	}
+	vm := &domain.VM{ID: "1", Name: "test-vm"}
+	runner := NewVMRunner(vm, cfg, RunConfig{}, false)
+	// No persist log started — logChan has no reader
+	// The trySendOrDrop calls in connectQMP must not block.
+
+	// Fill logChan to capacity (256)
+	for i := 0; i < 256; i++ {
+		runner.logChan <- "filler"
+	}
+
+	// These are the same patterns used in connectQMP
+	done := make(chan struct{})
+	go func() {
+		trySendOrDrop(runner.logChan, "[QMP] Connected to QEMU monitor")
+		trySendOrDrop(runner.logChan, "[vCPU pinning] WARNING: something")
+		trySendOrDrop(runner.logChan, "[QMP] WARNING: Failed to connect to QMP after timeout")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All writes completed without blocking
+	case <-time.After(3 * time.Second):
+		t.Fatal("connectQMP-style writes blocked on full logChan with no reader")
+	}
+}


### PR DESCRIPTION
## Description

Fixes critical channel deadlocks in VM runner. When subscriber/log channels are full and no goroutine is reading, the old drop-oldest pattern could block forever.

## Bugs Fixed

- **Bug 1 (CRITICAL):** `forwardViewLine` drop-oldest pattern blocks when subscriber channel full and no goroutine reading. The inner select takes `default`, then `ch <- line` blocks indefinitely.
- **Bug 2 (CRITICAL):** `connectQMP` writes `r.logChan <- ...` after `persistLogLoop` exits. No reader exists on `logChan` — buffer fills and subsequent writes block forever.
- Same pattern in `readOutput`, `readScriptOutput`, and `Subscribe()` staging drain.

## Changes

- Extract `trySendOrDrop()` helper: fully non-blocking send with drain-one-then-retry pattern
- Apply to all 5 call sites (forwardViewLine, readOutput, readScriptOutput, Subscribe staging-drain, connectQMP log writes)
- 4 new tests proving no deadlock with full channels and no reader

## Verification

- `go test ./...` — all 12 packages pass (130+ tests)
- 4 new deadlock-prevention tests pass
- Existing `TestPersistLogSlowFlushDoesNotBlock` continues to pass