### PR TITLE
fix(tui): terminal status freeze, width clamp, memory display

### DIFF
--- a/internal/tui/models/view.go
+++ b/internal/tui/models/view.go
@@ -314,11 +314,9 @@ func (m *MainModel) contentHeight() int {
 	return height
 }
 
-// effectiveWidth returns the window width clamped to minimum for safe rendering
+// effectiveWidth returns the window width.
+// No clamping — individual render functions handle minimum widths as needed.
 func (m *MainModel) effectiveWidth() int {
-	if m.windowWidth < 80 {
-		return 80
-	}
 	return m.windowWidth
 }
 

--- a/internal/tui/models/vm_running.go
+++ b/internal/tui/models/vm_running.go
@@ -332,8 +332,9 @@ func (m *VMRunningModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Don't overwrite stopping/stopped status from stale poll ticks
 		if m.status != "stopping" && m.status != "stopped" {
 			m.status = msg.Status
+			return m, m.pollStatus()
 		}
-		return m, m.pollStatus()
+		return m, nil
 
 	case VMMetricsUpdateMsg:
 		m.metrics = msg.Metrics
@@ -490,6 +491,10 @@ func (m *VMRunningModel) renderInfoPanel() string {
 		Foreground(styles.Colors.Warning).
 		Bold(true)
 
+	statusStopping := lipgloss.NewStyle().
+		Foreground(styles.Colors.Error).
+		Bold(true)
+
 	var b strings.Builder
 
 	// === Section 1: VM Name and Status ===
@@ -505,7 +510,7 @@ func (m *VMRunningModel) renderInfoPanel() string {
 	case "stopped", "exited", "shutdown":
 		statusStr = statusStopped.Render("[STOPPED]")
 	case "stopping", "finish":
-		statusStr = statusStarting.Render("[STOPPING]")
+		statusStr = statusStopping.Render("[STOPPING]")
 	default:
 		statusStr = statusStarting.Render("[STARTING]")
 	}
@@ -526,12 +531,7 @@ func (m *VMRunningModel) renderInfoPanel() string {
 	if m.runner != nil {
 		b.WriteString(labelStyle.Render("Memory: "))
 		memMB := m.runner.MemoryMB()
-		memGB := memMB / 1024
-		if memMB%1024 == 0 {
-			b.WriteString(valueStyle.Render(fmt.Sprintf("%d GB", memGB)))
-		} else {
-			b.WriteString(valueStyle.Render(fmt.Sprintf("%.1f GB", float64(memMB)/1024.0)))
-		}
+		b.WriteString(valueStyle.Render(fmt.Sprintf("%.1f GB", float64(memMB)/1024.0)))
 
 		// vCPU count
 		vcpuCount := m.runner.VCpuCount()

--- a/internal/tui/models/vm_running_test.go
+++ b/internal/tui/models/vm_running_test.go
@@ -125,6 +125,34 @@ func TestVMRunningModelStatusUpdate(t *testing.T) {
 	}
 }
 
+func TestVMRunningModelStatusUpdateStopped(t *testing.T) {
+	// When status is terminal ("stopped"), VMStatusUpdateMsg should NOT re-arm the poll tick.
+	m := setupRunningModel(t, "starting")
+	m.status = "stopped"
+	updated, cmd := m.Update(VMStatusUpdateMsg{Status: "running"})
+	m = updated.(*VMRunningModel)
+	if m.status != "stopped" {
+		t.Errorf("Expected status to remain 'stopped', got '%s'", m.status)
+	}
+	if cmd != nil {
+		t.Error("Expected nil command (no re-arm) when status is 'stopped' after VMStatusUpdateMsg")
+	}
+}
+
+func TestVMRunningModelStatusUpdateStopping(t *testing.T) {
+	// When status is terminal ("stopping"), VMStatusUpdateMsg should NOT re-arm the poll tick.
+	m := setupRunningModel(t, "starting")
+	m.status = "stopping"
+	updated, cmd := m.Update(VMStatusUpdateMsg{Status: "running"})
+	m = updated.(*VMRunningModel)
+	if m.status != "stopping" {
+		t.Errorf("Expected status to remain 'stopping', got '%s'", m.status)
+	}
+	if cmd != nil {
+		t.Error("Expected nil command (no re-arm) when status is 'stopping' after VMStatusUpdateMsg")
+	}
+}
+
 func TestVMRunningModelWindowSize(t *testing.T) {
 	m := setupRunningModel(t, "running")
 	m.ready = false


### PR DESCRIPTION
Fixes from ticket 6 bug bash.

**Changes:**
- **StatusUpdateMsg handling**: don't re-arm poll tick when VM status is terminal (stopping/stopped). Prevents stale ticks from overwriting status or issuing commands after teardown.
- **effectiveWidth**: remove 80-col clamping. Individual render functions handle min-width as needed.
- **Memory display**: always show GB with one decimal instead of conditional GB/MiB logic; simpler, consistent.
- **STOPPING style**: dedicated style with error color instead of reusing STARTING style.
- **Tests**: add `TestVMRunningModelStatusUpdateStopped` and `TestVMRunningModelStatusUpdateStopping` verifying terminal states don't re-arm poll.