### PR TITLE
fix(vm): goroutine & channel lifecycle cleanup

### DIFF
--- a/internal/vm/vm_runner.go
+++ b/internal/vm/vm_runner.go
@@ -52,7 +52,9 @@ type VMRunner struct {
 	persistFile *os.File
 	persistBuf  *bufio.Writer
 	persistQuit chan struct{}
-	persistWg   sync.WaitGroup
+	persistWg        sync.WaitGroup
+	closePersistOnce sync.Once
+	stopScriptWg     sync.WaitGroup
 
 	// Metrics snapshot state (for delta computation)
 	prevVCPUTime     map[int]int64               // ThreadID -> previous CPUTimeNs (absolute, in ns)
@@ -172,15 +174,11 @@ func (r *VMRunner) startPersistLog() error {
 // closePersistLog signals the flusher goroutine to stop, drains remaining lines,
 // flushes the buffered writer, and closes the file. It is safe to call multiple times.
 func (r *VMRunner) closePersistLog() {
-	// Idempotent close of persistQuit
-	if r.persistQuit != nil {
-		select {
-		case <-r.persistQuit:
-			// already closed
-		default:
+	r.closePersistOnce.Do(func() {
+		if r.persistQuit != nil {
 			close(r.persistQuit)
 		}
-	}
+	})
 	r.persistWg.Wait()
 }
 
@@ -1132,6 +1130,8 @@ func (r *VMRunner) Cleanup() {
 		os.Remove(r.socketPath)
 	}
 	// Ensure TPM process is terminated and state cleaned up
+	// Ensure stop-script reader goroutines have finished
+	r.stopScriptWg.Wait()
 	r.cleanupTPM()
 	// Close persisted log
 	r.closePersistLog()
@@ -1218,12 +1218,20 @@ func (r *VMRunner) monitorProcess() {
 	}
 }
 
-// qmpWatchdog periodically checks QMP connection status and logs diagnostics
+// qmpWatchdog periodically checks QMP connection status and logs diagnostics.
+// It exits when the VM is done (r.done closed), the process exits, or QMP connects.
 func (r *VMRunner) qmpWatchdog() {
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 
-	for range ticker.C {
+	for {
+		select {
+		case <-ticker.C:
+		case <-r.done:
+			// VM has exited, no need to keep watching
+			return
+		}
+
 		r.mu.Lock()
 		running := r.running
 		proc := r.cmdProcess
@@ -1521,8 +1529,15 @@ func (r *VMRunner) executeStopScript() {
 		}
 
 		// Read output in goroutines to avoid blocking
-		go r.readScriptOutput(stdout, "stop script stdout")
-		go r.readScriptOutput(stderr, "stop script stderr")
+		r.stopScriptWg.Add(2)
+		go func() {
+			defer r.stopScriptWg.Done()
+			r.readScriptOutput(stdout, "stop script stdout")
+		}()
+		go func() {
+			defer r.stopScriptWg.Done()
+			r.readScriptOutput(stderr, "stop script stderr")
+		}()
 
 		if err := cmd.Wait(); err != nil {
 			if r.dbgMode {
@@ -1563,8 +1578,15 @@ func (r *VMRunner) executeStopScript() {
 		}
 
 		// Read output in goroutines to avoid blocking
-		go r.readScriptOutput(stdout, "stop script stdout")
-		go r.readScriptOutput(stderr, "stop script stderr")
+		r.stopScriptWg.Add(2)
+		go func() {
+			defer r.stopScriptWg.Done()
+			r.readScriptOutput(stdout, "stop script stdout")
+		}()
+		go func() {
+			defer r.stopScriptWg.Done()
+			r.readScriptOutput(stderr, "stop script stderr")
+		}()
 
 		if err := cmd.Wait(); err != nil {
 			if r.dbgMode {

--- a/internal/vm/vm_runner_test.go
+++ b/internal/vm/vm_runner_test.go
@@ -1887,6 +1887,125 @@ func TestLogChanDoesNotBlockWhenFullNoReader(t *testing.T) {
 	}
 }
 
+// --- Goroutine & channel lifecycle cleanup tests ---
+
+func TestClosePersistLogConcurrent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vms", "1")
+	os.MkdirAll(vmDir, 0755)
+
+	cfg := &config.Config{
+		DataFolder: dir,
+		QEMUPath:   "/usr/bin/qemu-system-x86_64",
+	}
+	vm := &domain.VM{ID: "1", Name: "test-vm"}
+	runner := NewVMRunner(vm, cfg, RunConfig{}, false)
+
+	if err := runner.startPersistLog(); err != nil {
+		t.Fatalf("startPersistLog() failed: %v", err)
+	}
+
+	// Start multiple concurrent callers to closePersistLog
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runner.closePersistLog()
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All concurrent calls completed without panic
+	case <-time.After(3 * time.Second):
+		t.Fatal("Timed out: concurrent closePersistLog calls blocked")
+	}
+}
+
+func TestQMPWatchdogExitsOnDone(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vms", "1")
+	os.MkdirAll(vmDir, 0755)
+
+	cfg := &config.Config{
+		DataFolder: dir,
+		QEMUPath:   "/usr/bin/qemu-system-x86_64",
+	}
+	vm := &domain.VM{ID: "1", Name: "test-vm"}
+	runner := NewVMRunner(vm, cfg, RunConfig{}, true) // debug mode
+
+	// Start the watchdog goroutine
+	exited := make(chan struct{})
+	go func() {
+		runner.qmpWatchdog()
+		close(exited)
+	}()
+
+	// Give it a tick to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Close the done channel (simulates VM exit)
+	close(runner.done)
+
+	select {
+	case <-exited:
+		// Watchdog exited cleanly when done was closed
+	case <-time.After(3 * time.Second):
+		t.Fatal("qmpWatchdog did not exit when r.done was closed")
+	}
+}
+
+func TestCleanupWaitsForStopScriptGoroutines(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vms", "1")
+	os.MkdirAll(vmDir, 0755)
+
+	cfg := &config.Config{
+		DataFolder: dir,
+		QEMUPath:   "/usr/bin/qemu-system-x86_64",
+	}
+	vm := &domain.VM{ID: "1", Name: "test-vm"}
+	runner := NewVMRunner(vm, cfg, RunConfig{}, false)
+
+	// Manually add to stopScriptWg to simulate an in-flight goroutine
+	runner.stopScriptWg.Add(1)
+	scriptRunning := make(chan struct{})
+
+	go func() {
+		defer runner.stopScriptWg.Done()
+		close(scriptRunning)
+		// Simulate a long-running stop script reader
+		time.Sleep(100 * time.Millisecond)
+	}()
+
+	// Wait for goroutine to start
+	<-scriptRunning
+
+	// Cleanup should wait for the goroutine
+	done := make(chan struct{})
+	go func() {
+		runner.Cleanup()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Cleanup completed after goroutine finished
+	case <-time.After(3 * time.Second):
+		t.Fatal("Cleanup blocked waiting for stop-script goroutines")
+	}
+}
+
 func TestConnectQMPWritesDroppedGracefully(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/tickets.md
+++ b/tickets.md
@@ -56,10 +56,10 @@ After QMP connects, `connectQMP()` does `r.logChan <- "[QMP] Connected..."` (lin
 
 **Blocked by:** None — can start immediately
 
-- [ ] Add cancellation context or done-channel check to `qmpWatchdog`
-- [ ] Track and `Wait()` on stop-script reader goroutines before cleanup completes
-- [ ] Replace select-based guard in `closePersistLog` with `sync.Once`
-- [ ] Add tests: concurrent closePersistLog calls, goroutine lifecycle after Cleanup
+- [x] Add cancellation context or done-channel check to `qmpWatchdog`
+- [x] Track and `Wait()` on stop-script reader goroutines before cleanup completes
+- [x] Replace select-based guard in `closePersistLog` with `sync.Once`
+- [x] Add tests: concurrent closePersistLog calls, goroutine lifecycle after Cleanup
 
 ## Fix /proc/stat parsing robustness
 


### PR DESCRIPTION
Fixes bugs 7, 8, 18 from bugs.md.

## Changes

### Bug 7: qmpWatchdog goroutine leak
- Added select on r.done channel so watchdog exits immediately when VM is done
- Previously relied on !running check at next tick (up to 2s delay)

### Bug 8: Stop-script goroutines fire-and-forget
- Added stopScriptWg (sync.WaitGroup) to VMRunner
- Both stop-script code paths wrap readScriptOutput in tracked goroutines
- Cleanup() waits for stop-script goroutines before closing persist log

### Bug 18: closePersistLog double-close race
- Replaced select-based idempotency guard with sync.Once
- Eliminates race where concurrent callers both attempt close(r.persistQuit)

## Tests
- TestClosePersistLogConcurrent: 10 concurrent calls with no panic
- TestQMPWatchdogExitsOnDone: watchdog exits when r.done closed
- TestCleanupWaitsForStopScriptGoroutines: Cleanup() waits for tracked goroutines

## Verification
- Full test suite: `go test ./...` — all 200+ tests pass